### PR TITLE
CentOS7 and RES7 build files for packer

### DIFF
--- a/packer/centos7.json
+++ b/packer/centos7.json
@@ -1,0 +1,48 @@
+{
+  "provisioners": [{
+    "type": "shell",
+    "scripts": [
+      "scripts/base.sh",
+      "scripts/sumaform.sh",
+      "scripts/cleanup.sh"
+    ],
+    "override": {
+      "centos7": {
+        "execute_command": "sh '{{.Path}}'"
+      }
+    }
+  }],
+  "builders": [{
+      "name": "centos7",
+      "type": "qemu",
+      "iso_checksum": "f90e4d28fa377669b2db16cbcb451fcb9a89d2460e3645993e30e137ac37d284",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://ftp.tu-chemnitz.de/pub/linux/centos/7.2.1511/isos/x86_64/CentOS-7-x86_64-Minimal-1511.iso",
+      "ssh_wait_timeout": "30s",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 104858,
+      "format": "qcow2",
+      "qemuargs": [
+        [ "-m", "1024M" ],
+        ["-machine", "type=pc,accel=kvm"],
+        ["-device", "virtio-net-pci,netdev=user.0"]
+      ],
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "http_port_min": 10082,
+      "http_port_max": 10089,
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "root",
+      "ssh_password": "linux",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "vm_name": "centos7",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_centos7.cfg<enter><wait>"
+      ]
+    }]
+}

--- a/packer/http/ks_centos7.cfg
+++ b/packer/http/ks_centos7.cfg
@@ -29,6 +29,7 @@ url --url=http://mirror.centos.org/centos/7/os/x86_64/
 repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
 # repo to install salt-minion
 repo --name=sumatools --baseurl=http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
+repo --name=sumatools-final --baseurl=http://nu.novell.com/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/
 skipx
 zerombr
 

--- a/packer/http/ks_centos7.cfg
+++ b/packer/http/ks_centos7.cfg
@@ -1,0 +1,237 @@
+# See documentation:
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+
+# We want to "install"
+install
+
+cdrom
+
+# Fail when installation interactively prompts for anything
+cmdline
+
+# Set the language
+lang en_US.UTF-8
+
+keyboard us
+network --bootproto=dhcp
+
+# Sets the root password because we do not want any prompt during installation (password)
+rootpw linux
+
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512 --enablefingerprint
+selinux --disabled
+timezone Europe/Berlin
+bootloader --location=mbr
+
+# repo to install the OS
+url --url=http://mirror.centos.org/centos/7/os/x86_64/
+repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
+# repo to install salt-minion
+repo --name=sumatools --baseurl=http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
+skipx
+zerombr
+
+clearpart --all --initlabel
+part / --fstype ext4 --size=100000 --grow --asprimary
+
+reboot
+
+# install only base packages and openssh
+%packages --nobase --excludedocs --instLangs=en
+@Core
+-aic94xx-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-linux-firmware
+-b43-fwcutter
+-b43-openfwwf
+-perl
+-perl-Module-Pluggable
+-perl-Pod-Escapes
+-perl-Pod-Simple
+-perl-libs
+-perl-version
+-vim-enhanced
+-abrt
+-abrt-addon-ccpp
+-abrt-addon-kerneloops
+-abrt-addon-python
+-abrt-cli
+-abrt-libs
+-abrt-tui
+-libreport
+-libreport-cli
+-libreport-compat
+-libreport-plugin-kerneloops
+-libreport-plugin-logger
+-libreport-plugin-mailx
+-libreport-plugin-reportuploader
+-libreport-plugin-rhtsupport
+-libreport-python
+-cups-libs
+-fprintd
+-fprintd-pam
+-gtk2
+-libfprint
+-mysql-libs
+-cronie
+-cronie-anacron
+-crontabs
+-postfix
+-sysstat
+-alsa-lib
+-alsa-utils
+-man
+-man-pages
+-man-pages-overrides
+-yum-utils
+-system-config-firewall-base
+-system-config-firewall-tui
+-system-config-network-tui
+-systemtap-runtime
+-at
+-atk
+-bc
+-bind-libs
+-bind-utils
+-biosdevname
+-blktrace
+-busybox
+-cairo
+-centos-indexhtml
+-ConsoleKit
+-ConsoleKit-libs
+-cpuspeed
+-crda
+-cyrus-sasl-plain
+-dbus
+-dbus-python
+-desktop-file-utils
+-dmidecode
+-dmraid
+-dmraid-events
+-dosfstools
+-ed
+-eggdbus
+-eject
+-elfutils-libs
+-fontconfig
+-freetype
+-gnutls
+-hal
+-hal-info
+-hal-libs
+-hdparm
+-hicolor-icon-theme
+-hunspell
+-hunspell-en
+-irqbalance
+-iw
+-jasper-libs
+-kexec-tools
+-ledmon
+-libjpeg-turbo
+-libnl
+-libpcap
+-libpng
+-libtasn1
+-libthai
+-libtiff
+-libusb1
+-libX11
+-libX11-common
+-libXau
+-libxcb
+-libXcomposite
+-libXcursor
+-libXdamage
+-libXext
+-libXfixes
+-libXft
+-libXi
+-libXinerama
+-libxml2-python
+-libXrandr
+-libXrender
+-lsof
+-mailx
+-microcode_ctl
+-mlocate
+-mtr
+-nano
+-ntp
+-ntpdate
+-ntsysv
+-numactl
+-pam_passwdqc
+-pango
+-parted
+-pciutils
+-pcmciautils
+-pinfo
+-pixman
+-pkgconfig
+-pm-utils
+-polkit
+-prelink
+-psacct
+-python-ethtool
+-python-iwlib
+-quota
+-rdate
+-readahead
+-rfkill
+-rng-tools
+-rsync
+-scl-utils
+-setserial
+-setuptool
+-sg3_utils-libs
+-sgpio
+-smartmontools
+-sos
+-strace
+-tcpdump
+-tcp_wrappers
+-tcsh
+-time
+-tmpwatch
+-traceroute
+-unzip
+-usbutils
+-usermode
+-vconfig
+-wget
+-wireless-tools
+-words
+-xdg-utils
+-xz
+-xz-lzma-compat
+-yum-plugin-security
+-yum-utils
+-zip
+
+openssh-clients
+avahi
+qemu-guest-agent
+salt-minion
+
+%end
+
+%post --log=/root/post.log --nochroot
+
+# rebuild the initramfs
+# http://lists.openstack.org/pipermail/openstack/2015-January/011245.html
+# http://lists.openstack.org/pipermail/openstack/2014-August/008802.html
+dracut --force
+
+%end

--- a/packer/http/ks_res7.cfg
+++ b/packer/http/ks_res7.cfg
@@ -1,0 +1,237 @@
+# See documentation:
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+
+# We want to "install"
+install
+
+cdrom
+
+# Fail when installation interactively prompts for anything
+cmdline
+
+# Set the language
+lang en_US.UTF-8
+
+keyboard us
+network --bootproto=dhcp
+
+# Sets the root password because we do not want any prompt during installation (password)
+rootpw linux
+
+firewall --enabled --service=ssh
+authconfig --enableshadow --passalgo=sha512 --enablefingerprint
+selinux --disabled
+timezone Europe/Berlin
+bootloader --location=mbr
+
+# repo to install the OS
+repo --name=updates --baseurl=http://nu.novell.com/repo/$RCE/RES7/x86_64/
+# repo to install salt-minion
+repo --name=sumatools --baseurl=http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
+repo --name=sumatools-final --baseurl=http://nu.novell.com/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/
+skipx
+zerombr
+
+clearpart --all --initlabel
+part / --fstype ext4 --size=100000 --grow --asprimary
+
+reboot
+
+# install only base packages and openssh
+%packages --nobase --excludedocs --instLangs=en
+@Core
+-aic94xx-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-linux-firmware
+-b43-fwcutter
+-b43-openfwwf
+-perl
+-perl-Module-Pluggable
+-perl-Pod-Escapes
+-perl-Pod-Simple
+-perl-libs
+-perl-version
+-vim-enhanced
+-abrt
+-abrt-addon-ccpp
+-abrt-addon-kerneloops
+-abrt-addon-python
+-abrt-cli
+-abrt-libs
+-abrt-tui
+-libreport
+-libreport-cli
+-libreport-compat
+-libreport-plugin-kerneloops
+-libreport-plugin-logger
+-libreport-plugin-mailx
+-libreport-plugin-reportuploader
+-libreport-plugin-rhtsupport
+-libreport-python
+-cups-libs
+-fprintd
+-fprintd-pam
+-gtk2
+-libfprint
+-mysql-libs
+-cronie
+-cronie-anacron
+-crontabs
+-postfix
+-sysstat
+-alsa-lib
+-alsa-utils
+-man
+-man-pages
+-man-pages-overrides
+-yum-utils
+-system-config-firewall-base
+-system-config-firewall-tui
+-system-config-network-tui
+-systemtap-runtime
+-at
+-atk
+-bc
+-bind-libs
+-bind-utils
+-biosdevname
+-blktrace
+-busybox
+-cairo
+-centos-indexhtml
+-ConsoleKit
+-ConsoleKit-libs
+-cpuspeed
+-crda
+-cyrus-sasl-plain
+-dbus
+-dbus-python
+-desktop-file-utils
+-dmidecode
+-dmraid
+-dmraid-events
+-dosfstools
+-ed
+-eggdbus
+-eject
+-elfutils-libs
+-fontconfig
+-freetype
+-gnutls
+-hal
+-hal-info
+-hal-libs
+-hdparm
+-hicolor-icon-theme
+-hunspell
+-hunspell-en
+-irqbalance
+-iw
+-jasper-libs
+-kexec-tools
+-ledmon
+-libjpeg-turbo
+-libnl
+-libpcap
+-libpng
+-libtasn1
+-libthai
+-libtiff
+-libusb1
+-libX11
+-libX11-common
+-libXau
+-libxcb
+-libXcomposite
+-libXcursor
+-libXdamage
+-libXext
+-libXfixes
+-libXft
+-libXi
+-libXinerama
+-libxml2-python
+-libXrandr
+-libXrender
+-lsof
+-mailx
+-microcode_ctl
+-mlocate
+-mtr
+-nano
+-ntp
+-ntpdate
+-ntsysv
+-numactl
+-pam_passwdqc
+-pango
+-parted
+-pciutils
+-pcmciautils
+-pinfo
+-pixman
+-pkgconfig
+-pm-utils
+-polkit
+-prelink
+-psacct
+-python-ethtool
+-python-iwlib
+-quota
+-rdate
+-readahead
+-rfkill
+-rng-tools
+-rsync
+-scl-utils
+-setserial
+-setuptool
+-sg3_utils-libs
+-sgpio
+-smartmontools
+-sos
+-strace
+-tcpdump
+-tcp_wrappers
+-tcsh
+-time
+-tmpwatch
+-traceroute
+-unzip
+-usbutils
+-usermode
+-vconfig
+-wget
+-wireless-tools
+-words
+-xdg-utils
+-xz
+-xz-lzma-compat
+-yum-plugin-security
+-yum-utils
+-zip
+
+openssh-clients
+avahi
+qemu-guest-agent
+salt-minion
+
+%end
+
+%post --log=/root/post.log --nochroot
+
+# rebuild the initramfs
+# http://lists.openstack.org/pipermail/openstack/2015-January/011245.html
+# http://lists.openstack.org/pipermail/openstack/2014-August/008802.html
+dracut --force
+
+%end

--- a/packer/res7.json
+++ b/packer/res7.json
@@ -1,0 +1,48 @@
+{
+  "provisioners": [{
+    "type": "shell",
+    "scripts": [
+      "scripts/base.sh",
+      "scripts/sumaform.sh",
+      "scripts/cleanup.sh"
+    ],
+    "override": {
+      "res7": {
+        "execute_command": "sh '{{.Path}}'"
+      }
+    }
+  }],
+  "builders": [{
+      "name": "res7",
+      "type": "qemu",
+      "iso_checksum": "1348d8f69f058c04b58f32256d394b3091b027417ec4ffb5ce0b661d83403365",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://schnell.nue.suse.com/RHEL/SLES-ES/SLES-ES-7.2-x86_64-DVD.iso",
+      "ssh_wait_timeout": "30s",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 104858,
+      "format": "qcow2",
+      "qemuargs": [
+        [ "-m", "1024M" ],
+        ["-machine", "type=pc,accel=kvm"],
+        ["-device", "virtio-net-pci,netdev=user.0"]
+      ],
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "http_port_min": 10082,
+      "http_port_max": 10089,
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "root",
+      "ssh_password": "linux",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "vm_name": "res7",
+      "net_device": "virtio-net",
+      "disk_interface": "virtio",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_res7.cfg<enter><wait>"
+      ]
+    }]
+}

--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -3,4 +3,4 @@ yum -y clean all
 
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
-rm /etc/udev/rules.d/70-persistent-net.rules
+rm -f /etc/udev/rules.d/70-persistent-net.rules


### PR DESCRIPTION
This makes it possible to build images of those OSs via packer. The resulting images are stripped of packages galore, but aren't minimal.
