### PR TITLE
Add CentOS 7 image

### DIFF
--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -34,6 +34,12 @@ resource "libvirt_volume" "sles12sp2" {
   pool = "${var.pool}"
 }
 
+resource "libvirt_volume" "centos7" {
+  name = "${var.name_prefix}centos7"
+  source = "http://w3.suse.de/~mbologna/sumaform-images/centos7.qcow2"
+  pool = "${var.pool}"
+}
+  
 output "configuration" {
   // HACK: work around https://github.com/hashicorp/terraform/issues/9549
   value = "${

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "image" {
-  description = "One of: opensuse421, sles11sp3, sles11sp4, sles12, sles12sp1"
+  description = "One of: opensuse421, sles11sp3, sles11sp4, sles12, sles12sp1, centos7"
   type = "string"
 }
 

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1"
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, centos7"
   type = "string"
 }
 

--- a/packer/http/ks_centos7.cfg
+++ b/packer/http/ks_centos7.cfg
@@ -223,6 +223,7 @@ reboot
 
 openssh-clients
 avahi
+avahi-tools
 qemu-guest-agent
 salt-minion
 

--- a/packer/http/ks_centos7.cfg
+++ b/packer/http/ks_centos7.cfg
@@ -30,6 +30,7 @@ repo --name=updates --baseurl=http://mirror.centos.org/centos/7/updates/x86_64/
 # repo to install salt-minion
 repo --name=sumatools --baseurl=http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
 repo --name=sumatools-final --baseurl=http://nu.novell.com/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/
+repo --name=epel7 --baseurl=http://mirror.airenetworks.es/epel/7/x86_64/
 skipx
 zerombr
 
@@ -226,6 +227,7 @@ avahi
 avahi-tools
 qemu-guest-agent
 salt-minion
+nss-mdns
 
 %end
 

--- a/packer/http/ks_centos7.cfg
+++ b/packer/http/ks_centos7.cfg
@@ -18,7 +18,7 @@ network --bootproto=dhcp
 # Sets the root password because we do not want any prompt during installation (password)
 rootpw linux
 
-firewall --enabled --service=ssh
+firewall --disabled
 authconfig --enableshadow --passalgo=sha512 --enablefingerprint
 selinux --disabled
 timezone Europe/Berlin

--- a/salt/client/repos.sls
+++ b/salt/client/repos.sls
@@ -81,7 +81,8 @@ refresh-client-repos:
       - file: testsuite-build-repo
       - file: testsuite-suse-manager-repo
       {% endif %}
+{% else %}
+no-repos:
+  test.nop: []
 {% endif %}
 
-no-repos-configuration:
-  test.nop: []

--- a/salt/client/repos.sls
+++ b/salt/client/repos.sls
@@ -1,3 +1,4 @@
+{% if grains['os'] == 'SUSE' %}
 include:
   - sles.repos
 
@@ -80,3 +81,7 @@ refresh-client-repos:
       - file: testsuite-build-repo
       - file: testsuite-suse-manager-repo
       {% endif %}
+{% endif %}
+
+no-repos-configuration:
+  test.nop: []


### PR DESCRIPTION
Add support for spinning up CentOS 7 images.
**WARNING**: due to package-mirror dependency on base/main.tf#configuration , your package-mirror will be **deleted** when applying this patch. Backup accordingly.