### PR TITLE
Feat: package-mirror data disk with XFS

### DIFF
--- a/salt/package-mirror/init.sls
+++ b/salt/package-mirror/init.sls
@@ -37,7 +37,7 @@ mirror-script:
 
 mirror-partition:
   cmd.run:
-    - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev//{{grains['data_disk_device']}} mkpart primary 2048 100% && /sbin/mkfs.ext4 /dev//{{grains['data_disk_device']}}1
+    - name: /usr/sbin/parted -s /dev/{{grains['data_disk_device']}} mklabel gpt && /usr/sbin/parted -s /dev//{{grains['data_disk_device']}} mkpart primary 2048 100% && /sbin/mkfs.xfs /dev//{{grains['data_disk_device']}}1
     - unless: ls /dev//{{grains['data_disk_device']}}1
 
 # http serving of mirrored packages
@@ -55,7 +55,7 @@ mirror-directory:
   mount.mounted:
     - name: /srv/mirror
     - device: /dev//{{grains['data_disk_device']}}1
-    - fstype: ext4
+    - fstype: xfs
     - mkmnt: True
     - persist: True
     - opts:


### PR DESCRIPTION
This patch changes the file-system for package-mirror data disk to XFS
(for obvious performance reasons).
This patch applies only to newly created package-mirrors.

NOTE: existing package-mirrors cannot be used with package mirrors created after applying this patch.