### PR TITLE
Feature: access systems without rsa-key

### DIFF
--- a/packer/scripts/base.sh
+++ b/packer/scripts/base.sh
@@ -6,3 +6,6 @@ yum -y install ca-certificates
 
 # Make ssh faster by not waiting on DNS
 echo "UseDNS no" >> /etc/ssh/sshd_config
+
+# by default redhat disable ssh passwords, we want to access the system with our standard pwd.
+sed -i -e 's/^ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/g' /etc/ssh/sshd_config 


### PR DESCRIPTION
Until now, for accessing the centos image, we have to put a ssh-key
This is because of redhat standart policy.
For testing systems we prefer to use password auth.