### PR TITLE
perform a salt self update in seperate salt-call to prevent failures

### DIFF
--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -59,6 +59,7 @@ EOF
   provisioner "remote-exec" {
     inline = [
       "salt-call --force-color --local state.sls terraform-resource",
+      "salt-call --force-color --local state.sls selfupdate",
       "salt-call --force-color --local state.highstate"
     ]
   }

--- a/salt/selfupdate/init.sls
+++ b/salt/selfupdate/init.sls
@@ -1,0 +1,27 @@
+
+include:
+{% if grains['role'] == 'client' or grains['role'] == 'minion' %}
+  - client.repos
+{% elif grains['role'] == 'suse-manager-server' %}
+- suse-manager.repos
+{% elif grains['role'] == 'suse-manager-proxy' %}
+- suse-manager-proxy.repos
+{% elif grains['role'] == 'control-node' %}
+- control-node.repos
+{% endif %}
+
+salt-allow-vendor-changes:
+  file.managed:
+    - name: /etc/zypp/vendors.d/suse
+    - makedirs: True
+    - contents: |
+        [main]
+        vendors = SUSE,obs://build.suse.de/Devel:Galaxy:Manager
+
+update-salt:
+  pkg.latest:
+    - pkgs:
+      - salt
+      - salt-minion
+    - requires:
+      - file: salt-allow-vendor-changes


### PR DESCRIPTION
Doing a salt major version update in a big highstate result into errors.
Seems that salt re-load state and modules code after the update but not
imported utilities.
That means: new modules call old (while in memory) utility functions with
the consequence that a called function might not exist.