### PR TITLE
Only restart 'salt-api' is salt-api is installed.

### DIFF
--- a/salt/suse-manager/salt.sls
+++ b/salt/suse-manager/salt.sls
@@ -24,6 +24,6 @@ salt:
 # and restart.sls from salt don't work
 salt-api:
   cmd.run:
-   - name: systemctl restart salt-api
+   - name: service salt-api restart
    - require:
-      - pkg: salt
+      - pkg: salt-api


### PR DESCRIPTION
Salt is used by sumaform for provisioning, so `salt` package is always installed in every deployed machine but not the `salt-api` package.

This PR fixes the "HACK" to restart the `salt-api` in order to prevent errors during provisioning if `salt-api` doesn't exist.

Also prevent an error trying to run `systemctl restart salt-api` if running OS uses SysV.