### PR TITLE
Fix tomcat 8 remote debug config

### DIFF
--- a/salt/suse-manager/tomcat.sls
+++ b/salt/suse-manager/tomcat.sls
@@ -61,6 +61,13 @@ tomcat-config:
     - require:
       - sls: suse-manager.rhn
 
+tomcat-config-loaded:
+  file.comment:
+    - name: /etc/tomcat/tomcat.conf
+    - regex: '^TOMCAT_CFG_LOADED.*'
+    - require:
+      - sls: suse-manager.rhn
+
 tomcat:
   service.running:
     - watch:


### PR DESCRIPTION
The following line in the config file prevents Tomcat from applying the configuration.
```
# This variable is used to figure out if config is loaded or not.
TOMCAT_CFG_LOADED="1"
```
This PR modifies the state file to comment-out the specified line.