### PR TITLE
Fix id because it conflicts with something on suma

### DIFF
--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -2,11 +2,13 @@ include:
   - client.repos
   - minion.testsuite
 
-salt-minion:
+minion:
   pkg.installed:
+    - name: salt-minion
     - require:
       - sls: client.repos
   service.running:
+    - name: salt-minion
     - enable: True
     - watch:
       - pkg: salt-minion


### PR DESCRIPTION
There is a bug just recently where calling the highstate fails because of a conflicting id.  @mc fixed an issue in SUSE Manager where he used salt-minion in a state.  
>>> output here

    rfsuma3pg:~ # salt rfminsles12sp1* state.highstate
    rfminsles12sp1.tf.local:
        Data failed to compile:
    ----------
        Detected conflicting IDs, SLS IDs need to be globally unique.
    include:
        The conflicting ID is 'salt-minion' and is found in SLS 'base:minion' and SLS 'base:services.salt-minion'
    ERROR: Minions returned with non-zero exit code


Renaming this from salt-minion to just minion makes the highstate apply successfully.