### PR TITLE
Add "memory" as a possible setting for the control node

### DIFF
--- a/modules/libvirt/control_node/main.tf
+++ b/modules/libvirt/control_node/main.tf
@@ -3,6 +3,7 @@ module "control_node" {
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
   image = "sles12sp1"
+  memory = "${var.memory}"
   running = "${var.running}"
   mac = "${var.mac}"
   grains = <<EOF

--- a/modules/libvirt/control_node/variables.tf
+++ b/modules/libvirt/control_node/variables.tf
@@ -39,6 +39,11 @@ variable "centos_configuration" {
   type = "map"
 }
 
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 512
+}
+
 variable "running" {
   description = "Whether this host should be turned on or off"
   default = true


### PR DESCRIPTION
Augmenting the control node's memory is one way to solve the problem of phantomJS crashes. More generally, this setting might reveal useful in other situations.