### PR TITLE
configure extra repositories and extra packages via variable

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -193,3 +193,28 @@ module "suma31pg" {
 
 Note that the version is called `stable` in continuity with the existing naming schema because it will target the final release of SUSE Manager 3.1.
 However, at the time of writing, this version is still in alpha.
+
+### Add custom repos and packages
+
+You can specify custom repos and packages to be installed at deploy time for a specific host:
+
+```hcl
+module "minsles12sp1" {
+  source = "./modules/libvirt/minion"
+  base_configuration = "${module.base.configuration}"
+
+  name = "minsles12sp1"
+  image = "sles12sp1"
+  server_configuration = "${module.suma3pg.configuration}"
+
+  additional_repos {
+    tools = "http://download.opensuse.org/repositories/home:/SilvioMoioli:/tools/SLE_12_SP2/"
+    virtualization_containers = "http://download.opensuse.org/repositories/Virtualization:/containers/SLE_12_SP2/"
+  }
+
+  additional_packages = [
+    "terraform",
+    "htop"
+  ]
+}
+```

--- a/main.tf.aws.example
+++ b/main.tf.aws.example
@@ -31,7 +31,7 @@ module "aws_package_mirror" {
   ami = "ami-33ee1f25" // change if appropriate (non-SUSE employees or non-us-east-1 region)
   key_name = // add SSH key name as a string here
   key_file = // add SSH private key path as a string here
-  data_volume_snapshot_id = "snap-011acc89" // change if appropriate (non-SUSE employees or non-us-east-1 region)
+  data_volume_snapshot_id = "snap-09de67b10c0637b66" // change if appropriate (non-SUSE employees or non-us-east-1 region)
   public_subnet_id = "${module.aws_network.public_subnet_id}"
   public_security_group_id = "${module.aws_network.public_security_group_id}"
   cc_username = "${var.cc_username}"

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -14,7 +14,7 @@ variable "availability_zone" {
 }
 
 variable "ami" {
-  description = "AMI of the custom openSUSE Terraform image for the us-east-1 region, see modules/aws/images"
+  description = "AMI image for the selected for the configured region, see modules/aws/images"
   type = "string"
 }
 

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -9,6 +9,7 @@ module "client" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -8,6 +8,7 @@ module "client" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 version: ${var.version}
@@ -16,8 +17,6 @@ server: ${var.server_configuration["hostname"]}
 role: client
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -16,6 +16,8 @@ server: ${var.server_configuration["hostname"]}
 role: client
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -8,8 +8,8 @@ module "client" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -62,3 +62,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -33,6 +33,16 @@ variable "for_testsuite_only" {
   default = false
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "count"  {
   description = "number of hosts like this one"
   default = 1
@@ -56,14 +66,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -57,3 +57,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -58,12 +58,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/control_node/main.tf
+++ b/modules/libvirt/control_node/main.tf
@@ -6,8 +6,8 @@ module "control_node" {
   memory = "${var.memory}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}

--- a/modules/libvirt/control_node/main.tf
+++ b/modules/libvirt/control_node/main.tf
@@ -16,5 +16,7 @@ centos-minion: ${var.centos_configuration["hostname"]}
 ssh-minion: ${var.minionssh_configuration["hostname"]}
 role: control-node
 branch : ${var.branch}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 EOF
 }

--- a/modules/libvirt/control_node/main.tf
+++ b/modules/libvirt/control_node/main.tf
@@ -7,6 +7,7 @@ module "control_node" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}

--- a/modules/libvirt/control_node/main.tf
+++ b/modules/libvirt/control_node/main.tf
@@ -6,6 +6,7 @@ module "control_node" {
   memory = "${var.memory}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}
@@ -16,7 +17,5 @@ centos-minion: ${var.centos_configuration["hostname"]}
 ssh-minion: ${var.minionssh_configuration["hostname"]}
 role: control-node
 branch : ${var.branch}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 EOF
 }

--- a/modules/libvirt/control_node/variables.tf
+++ b/modules/libvirt/control_node/variables.tf
@@ -54,12 +54,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/control_node/variables.tf
+++ b/modules/libvirt/control_node/variables.tf
@@ -58,3 +58,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/control_node/variables.tf
+++ b/modules/libvirt/control_node/variables.tf
@@ -53,3 +53,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/control_node/variables.tf
+++ b/modules/libvirt/control_node/variables.tf
@@ -39,6 +39,16 @@ variable "centos_configuration" {
   type = "map"
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 1024
@@ -52,14 +62,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -51,6 +51,8 @@ domain: ${var.base_configuration["domain"]}
 use-avahi: ${var.base_configuration["use_avahi"]}
 ${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
 ${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
+${length(var.extra_pkgs) > 0 ? "extra_pkgs:" : ""}
+${length(var.extra_pkgs) > 0 ? join("\n", formatlist("  - %s", var.extra_pkgs)) : ""}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -49,6 +49,8 @@ resource "libvirt_domain" "domain" {
 hostname: ${var.base_configuration["name_prefix"]}${var.name}${element(list("", "-${count.index  + 1}"), signum(var.count - 1))}
 domain: ${var.base_configuration["domain"]}
 use-avahi: ${var.base_configuration["use_avahi"]}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -60,6 +60,7 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
+      "test -e /etc/fstab || touch /etc/fstab",
       "salt-call --force-color --local --output=quiet state.sls default,terraform-resource",
       "salt-call --force-color --local state.highstate"
     ]

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -49,10 +49,10 @@ resource "libvirt_domain" "domain" {
 hostname: ${var.base_configuration["name_prefix"]}${var.name}${element(list("", "-${count.index  + 1}"), signum(var.count - 1))}
 domain: ${var.base_configuration["domain"]}
 use-avahi: ${var.base_configuration["use_avahi"]}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
-${length(var.extra_pkgs) > 0 ? "extra_pkgs:" : ""}
-${length(var.extra_pkgs) > 0 ? join("\n", formatlist("  - %s", var.extra_pkgs)) : ""}
+${length(var.additional_repos) > 0 ? "additional_repos:" : ""}
+${length(var.additional_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.additional_repos), values(var.additional_repos))) : ""}
+${length(var.additional_packages) > 0 ? "additional_packages:" : ""}
+${length(var.additional_packages) > 0 ? join("\n", formatlist("  - %s", var.additional_packages)) : ""}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -49,10 +49,8 @@ resource "libvirt_domain" "domain" {
 hostname: ${var.base_configuration["name_prefix"]}${var.name}${element(list("", "-${count.index  + 1}"), signum(var.count - 1))}
 domain: ${var.base_configuration["domain"]}
 use-avahi: ${var.base_configuration["use_avahi"]}
-${length(var.additional_repos) > 0 ? "additional_repos:" : ""}
-${length(var.additional_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.additional_repos), values(var.additional_repos))) : ""}
-${length(var.additional_packages) > 0 ? "additional_packages:" : ""}
-${length(var.additional_packages) > 0 ? join("\n", formatlist("  - %s", var.additional_packages)) : ""}
+additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
+additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ${var.grains}
 
 EOF

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -13,6 +13,16 @@ variable "image" {
   type = "string"
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "count"  {
   description = "number of hosts like this one"
   default = 1
@@ -46,14 +56,4 @@ variable "additional_disk" {
 variable "grains" {
   description = "custom grain string to be added to this host's configuration"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -52,3 +52,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -48,12 +48,12 @@ variable "grains" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -47,3 +47,8 @@ variable "grains" {
   description = "custom grain string to be added to this host's configuration"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -8,6 +8,7 @@ module "minion" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 version: ${var.version}
@@ -16,8 +17,6 @@ server: ${var.server_configuration["hostname"]}
 role: minion
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -8,8 +8,8 @@ module "minion" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -9,6 +9,7 @@ module "minion" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -16,6 +16,8 @@ server: ${var.server_configuration["hostname"]}
 role: minion
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -62,3 +62,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -33,6 +33,16 @@ variable "for_testsuite_only" {
   default = false
 }
 
+variable "additional_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages which should be installed"
+  default = []
+}
+
 variable "count"  {
   description = "number of hosts like this one"
   default = 1
@@ -56,14 +66,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -57,3 +57,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -58,12 +58,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/package_mirror/main.tf
+++ b/modules/libvirt/package_mirror/main.tf
@@ -17,6 +17,7 @@ module "package_mirror" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
 
   additional_disk {
     volume_id = "${libvirt_volume.data_disk.id}"

--- a/modules/libvirt/package_mirror/main.tf
+++ b/modules/libvirt/package_mirror/main.tf
@@ -16,8 +16,8 @@ module "package_mirror" {
   vcpu = 1
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
 
   additional_disk {
     volume_id = "${libvirt_volume.data_disk.id}"

--- a/modules/libvirt/package_mirror/main.tf
+++ b/modules/libvirt/package_mirror/main.tf
@@ -27,6 +27,8 @@ role: package-mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/package_mirror/main.tf
+++ b/modules/libvirt/package_mirror/main.tf
@@ -16,19 +16,18 @@ module "package_mirror" {
   vcpu = 1
   running = "${var.running}"
   mac = "${var.mac}"
-  
+  extra_repos = "${var.extra_repos}"
+
   additional_disk {
     volume_id = "${libvirt_volume.data_disk.id}"
   }
-  
+
   grains = <<EOF
 
 role: package-mirror
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/package_mirror/variables.tf
+++ b/modules/libvirt/package_mirror/variables.tf
@@ -9,6 +9,16 @@ variable "running" {
   default = true
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "data_pool" {
   description = "libvirt storage pool name for this host's data disk"
   default = "default"
@@ -17,14 +27,4 @@ variable "data_pool" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/package_mirror/variables.tf
+++ b/modules/libvirt/package_mirror/variables.tf
@@ -18,3 +18,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/package_mirror/variables.tf
+++ b/modules/libvirt/package_mirror/variables.tf
@@ -19,12 +19,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/package_mirror/variables.tf
+++ b/modules/libvirt/package_mirror/variables.tf
@@ -23,3 +23,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/postgres/main.tf
+++ b/modules/libvirt/postgres/main.tf
@@ -8,6 +8,7 @@ module "postgres" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}

--- a/modules/libvirt/postgres/main.tf
+++ b/modules/libvirt/postgres/main.tf
@@ -7,13 +7,12 @@ module "postgres" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}
 role: postgres
 for-development-only: True
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/postgres/main.tf
+++ b/modules/libvirt/postgres/main.tf
@@ -12,6 +12,8 @@ module "postgres" {
 package-mirror: ${var.base_configuration["package_mirror"]}
 role: postgres
 for-development-only: True
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/postgres/main.tf
+++ b/modules/libvirt/postgres/main.tf
@@ -7,8 +7,8 @@ module "postgres" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 package-mirror: ${var.base_configuration["package_mirror"]}

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -27,3 +27,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -13,6 +13,16 @@ variable "memory" {
   default = 4096
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "vcpu" {
   description = "Number of virtual CPUs"
   default = 2
@@ -26,14 +36,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -28,12 +28,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -32,3 +32,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -20,6 +20,7 @@ module "suse_manager" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -31,6 +31,8 @@ iss-slave: ${var.iss_slave}
 role: suse-manager-server
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  - %s", var.extra_repos)) : ""}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -19,8 +19,8 @@ module "suse_manager" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -32,7 +32,7 @@ role: suse-manager-server
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
 ${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  - %s", var.extra_repos)) : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -19,6 +19,7 @@ module "suse_manager" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 version: ${var.version}
@@ -31,8 +32,6 @@ iss-slave: ${var.iss_slave}
 role: suse-manager-server
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
 for-testsuite-only: ${element(list("False", "True"), var.for_testsuite_only)}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -64,6 +64,6 @@ variable "mac" {
 }
 
 variable "extra_repos" {
-  description = "extra repositories used for installation"
+  description = "extra repositories used for installation {label = url}"
   default = {}
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -63,12 +63,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -65,5 +65,5 @@ variable "mac" {
 
 variable "extra_repos" {
   description = "extra repositories used for installation"
-  default = []
+  default = {}
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -62,3 +62,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation"
+  default = []
+}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -43,6 +43,16 @@ variable "for_testsuite_only" {
   default = false
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 4096
@@ -61,14 +71,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -67,3 +67,8 @@ variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }
+
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -18,6 +18,7 @@ module "suse_manager_proxy" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  extra_repos = "${var.extra_repos}"
   grains = <<EOF
 
 version: ${var.version}
@@ -25,8 +26,6 @@ package-mirror: ${var.base_configuration["package_mirror"]}
 server: ${var.server_configuration["hostname"]}
 role: suse-manager-proxy
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
-${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
-${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -25,6 +25,8 @@ package-mirror: ${var.base_configuration["package_mirror"]}
 server: ${var.server_configuration["hostname"]}
 role: suse-manager-proxy
 for-development-only: ${element(list("False", "True"), var.for_development_only)}
+${length(var.extra_repos) > 0 ? "extra_repos:" : ""}
+${length(var.extra_repos) > 0 ? join("\n", formatlist("  %s: %s", keys(var.extra_repos), values(var.extra_repos))) : ""}
 
 EOF
 }

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -18,8 +18,8 @@ module "suse_manager_proxy" {
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
-  extra_repos = "${var.extra_repos}"
-  extra_pkgs = "${var.extra_pkgs}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -19,6 +19,7 @@ module "suse_manager_proxy" {
   running = "${var.running}"
   mac = "${var.mac}"
   extra_repos = "${var.extra_repos}"
+  extra_pkgs = "${var.extra_pkgs}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -23,6 +23,16 @@ variable "for_development_only" {
   default = true
 }
 
+variable "additional_repos" {
+  description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages to install, see README_ADVANCED.md"
+  default = []
+}
+
 variable "count"  {
   description = "number of hosts like this one"
   default = 1
@@ -46,14 +56,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default = []
-}
-
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default = {}
 }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -47,3 +47,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "extra_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -48,6 +48,11 @@ variable "mac" {
   default = ""
 }
 
+variable "extra_pkgs" {
+  description = "extra packages which should be installed"
+  default = []
+}
+
 variable "extra_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -48,12 +48,12 @@ variable "mac" {
   default = ""
 }
 
-variable "extra_pkgs" {
+variable "additional_packages" {
   description = "extra packages which should be installed"
   default = []
 }
 
-variable "extra_repos" {
+variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}
 }

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -1,5 +1,6 @@
 include:
   - default.repos
+  - default.pkgs
 
 up-to-date-salt:
   pkg.latest:

--- a/salt/default/pkgs.sls
+++ b/salt/default/pkgs.sls
@@ -1,10 +1,10 @@
-{% if 'extra_pkgs' in grains %}
-install_extra_packages:
+{% if 'additional_packages' in grains %}
+install_additional_packages:
   pkg.latest:
     - require:
       - sls: default.repos
     - pkgs:
-{% for pkg in grains['extra_pkgs'] %}
+{% for pkg in grains['additional_packages'] %}
       - {{pkg}}
 {% endfor %}
 {% endif %}

--- a/salt/default/pkgs.sls
+++ b/salt/default/pkgs.sls
@@ -1,10 +1,10 @@
-{% if 'additional_packages' in grains %}
+{% if grains['additional_packages'] %}
 install_additional_packages:
   pkg.latest:
+    - pkgs:
+{% for package in grains['additional_packages'] %}
+      - {{ package }}
+{% endfor %}
     - require:
       - sls: default.repos
-    - pkgs:
-{% for pkg in grains['additional_packages'] %}
-      - {{pkg}}
-{% endfor %}
 {% endif %}

--- a/salt/default/pkgs.sls
+++ b/salt/default/pkgs.sls
@@ -1,0 +1,10 @@
+{% if 'extra_pkgs' in grains %}
+install_extra_packages:
+  pkg.latest:
+    - require:
+      - sls: default.repos
+    - pkgs:
+{% for pkg in grains['extra_pkgs'] %}
+      - {{pkg}}
+{% endfor %}
+{% endif %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -151,8 +151,8 @@ tools-update-repo:
 {% endif %}
 {% endif %}
 
-{% if 'extra_repos' in grains %}
-{% for label, url in grains['extra_repos'].items() %}
+{% if 'additional_repos' in grains %}
+{% for label, url in grains['additional_repos'].items() %}
 {{ label }}:
   pkgrepo.managed:
     - humanname: {{ label }}
@@ -180,8 +180,8 @@ refresh-default-repos:
 
 {% else %}
 
-{% if 'extra_repos' in grains %}
-{% for label, url in grains['extra_repos'].items() %}
+{% if 'additional_repos' in grains %}
+{% for label, url in grains['additional_repos'].items() %}
 {{ label }}:
   pkgrepo.managed:
     - humanname: {{ label }}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -151,14 +151,6 @@ tools-update-repo:
 {% endif %}
 {% endif %}
 
-{% for label, url in grains['additional_repos'].items() %}
-{{ label }}-repo:
-  pkgrepo.managed:
-    - humanname: {{ label }}
-    - baseurl: {{ url }}
-    - priority: 98
-{% endfor %}
-
 allow-vendor-changes:
   file.managed:
     - name: /etc/zypp/vendors.d/suse
@@ -176,18 +168,15 @@ refresh-default-repos:
       - file: tools-pool-repo
       - file: tools-update-repo
 
-{% else %}
+{% endif %}
 
-{% if 'additional_repos' in grains %}
 {% for label, url in grains['additional_repos'].items() %}
-{{ label }}:
+{{ label }}-repo:
   pkgrepo.managed:
     - humanname: {{ label }}
     - baseurl: {{ url }}
     - priority: 98
 {% endfor %}
-{% endif %}
 
-no-default-repos:
+default-repos:
   test.nop: []
-{% endif %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -151,6 +151,15 @@ tools-update-repo:
 {% endif %}
 {% endif %}
 
+{% if 'extra_repos' in grains %}
+{% for label, url in grains['extra_repos'].items() %}
+{{ label }}:
+  pkgrepo.managed:
+    - baseurl: {{ url }}
+    - priority: 98
+{% endfor %}
+{% endif %}
+
 allow-vendor-changes:
   file.managed:
     - name: /etc/zypp/vendors.d/suse
@@ -158,7 +167,7 @@ allow-vendor-changes:
     - contents: |
         [main]
         vendors = SUSE,obs://build.suse.de/Devel:Galaxy
-    
+
 refresh-default-repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
@@ -169,6 +178,16 @@ refresh-default-repos:
       - file: tools-update-repo
 
 {% else %}
+
+{% if 'extra_repos' in grains %}
+{% for label, url in grains['extra_repos'].items() %}
+{{ label }}:
+  pkgrepo.managed:
+    - baseurl: {{ url }}
+    - priority: 98
+{% endfor %}
+{% endif %}
+
 no-default-repos:
   test.nop: []
 {% endif %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -151,15 +151,13 @@ tools-update-repo:
 {% endif %}
 {% endif %}
 
-{% if 'additional_repos' in grains %}
 {% for label, url in grains['additional_repos'].items() %}
-{{ label }}:
+{{ label }}-repo:
   pkgrepo.managed:
     - humanname: {{ label }}
     - baseurl: {{ url }}
     - priority: 98
 {% endfor %}
-{% endif %}
 
 allow-vendor-changes:
   file.managed:

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -155,6 +155,7 @@ tools-update-repo:
 {% for label, url in grains['extra_repos'].items() %}
 {{ label }}:
   pkgrepo.managed:
+    - humanname: {{ label }}
     - baseurl: {{ url }}
     - priority: 98
 {% endfor %}
@@ -183,6 +184,7 @@ refresh-default-repos:
 {% for label, url in grains['extra_repos'].items() %}
 {{ label }}:
   pkgrepo.managed:
+    - humanname: {{ label }}
     - baseurl: {{ url }}
     - priority: 98
 {% endfor %}

--- a/salt/package-mirror/mirror.sh
+++ b/salt/package-mirror/mirror.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -x
 
-# HACK: workaround for https://infra.nue.suse.com/SelfService/Display.html?id=49948
-ping -c 1 euklid.suse.de
-
 cd /srv/mirror
 lftp -f /root/mirror.lftp >/var/log/lftp.log 2>/var/log/lftp.err
 /root/refresh_scc_data.py {{ grains.get("cc_username") }}:{{ grains.get("cc_password") }}

--- a/salt/suse-manager/repos.sls
+++ b/salt/suse-manager/repos.sls
@@ -122,15 +122,6 @@ lftp-repo:
       - sls: default
 {% endif %}
 
-{% if 'extra_repos' in grains %}
-{% for label, url in grains['extra_repos'].items() %}
-{{ label }}:
-  pkgrepo.managed:
-    - baseurl: {{ url }}
-    - priority: 98
-{% endfor %}
-{% endif %}
-
 refresh-suse-manager-repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh

--- a/salt/suse-manager/repos.sls
+++ b/salt/suse-manager/repos.sls
@@ -122,6 +122,15 @@ lftp-repo:
       - sls: default
 {% endif %}
 
+{% if 'extra_repos' in grains %}
+{% for repo in grains['extra_repos'] %}
+{{ repo }}:
+  pkgrepo.managed:
+    - baseurl: {{ repo }}
+    - priority: 98
+{% endfor %}
+{% endif %}
+
 refresh-suse-manager-repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh

--- a/salt/suse-manager/repos.sls
+++ b/salt/suse-manager/repos.sls
@@ -123,10 +123,10 @@ lftp-repo:
 {% endif %}
 
 {% if 'extra_repos' in grains %}
-{% for repo in grains['extra_repos'] %}
-{{ repo }}:
+{% for label, url in grains['extra_repos'].items() %}
+{{ label }}:
   pkgrepo.managed:
-    - baseurl: {{ repo }}
+    - baseurl: {{ url }}
     - priority: 98
 {% endfor %}
 {% endif %}

--- a/salt/terraform-resource/init.sls
+++ b/salt/terraform-resource/init.sls
@@ -62,8 +62,3 @@ setup-machine-id-with-dbus:
 clear-minion-id:
   file.absent:
     - name: /etc/salt/minion_id
-
-# HACK: workaround for https://infra.nue.suse.com/SelfService/Display.html?id=49948
-work-around-networking-issue:
-  cmd.run:
-    - name: ping -c 1 euklid.suse.de; true


### PR DESCRIPTION
This allows to configure additional repositories to be used by simply defining them in main.tf as a variable.
(requires a newer version of terraform. Tested with version 0.8.6)

```
module "suma-headpg" {
  source = "./modules/libvirt/suse_manager"
  base_configuration = "${module.base.configuration}"

  name = "suma-headpg"
  version = "head"
  memory = 4096
  extra_repos = [ "http://download.domain.top/my/devel/repository" ]
  // see modules/libvirt/suse_manager/variables.tf for possible values
}
```
