### PR TITLE
add smt variable to suse_manager to configure a from mirror

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -194,6 +194,21 @@ module "suma31pg" {
 Note that the version is called `stable` in continuity with the existing naming schema because it will target the final release of SUSE Manager 3.1.
 However, at the time of writing, this version is still in alpha.
 
+### SMT
+
+You can configure SUSE Manager instances to download packages from an SMT server instead of SCC, in case a package mirror is not used:
+
+```hcl
+module "suma3pg" {
+  source = "./modules/libvirt/suse_manager"
+  base_configuration = "${module.base.configuration}"
+
+  name = "suma3pg"
+  version = "3-nightly"
+  smt = "http://smt.suse.de"
+}
+```
+
 ### Add custom repos and packages
 
 You can specify custom repos and packages to be installed at deploy time for a specific host:

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -30,6 +30,7 @@ database: ${var.database}
 package-mirror: ${var.base_configuration["package_mirror"]}
 iss-master: ${var.iss_master}
 iss-slave: ${var.iss_slave}
+smt: ${var.smt}
 role: suse-manager-server
 for-development-only: ${var.for_development_only ? "True" : "False"}
 for-testsuite-only: ${var.for_testsuite_only ? "True" : "False"}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -43,6 +43,11 @@ variable "for_testsuite_only" {
   default = false
 }
 
+variable "smt" {
+  description = "URL to an SMT server to get packages from"
+  default = "null"
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default = {}

--- a/salt/suse-manager/rhn.sls
+++ b/salt/suse-manager/rhn.sls
@@ -142,6 +142,15 @@ rhn-conf-from-dir:
       - sls: suse-manager
       - mount: mirror-directory
 
+{% elif salt["grains.get"]("smt") %}
+
+rhn-conf-mirror:
+  file.append:
+    - name: /etc/rhn/rhn.conf
+    - text: server.susemanager.mirror = {{ salt["grains.get"]("smt") }}
+    - require:
+      - sls: suse-manager
+
 {% endif %}
 
 {% endif %}


### PR DESCRIPTION
The light alternative to package-mirror: configure the URL of an SMT server to get the packages from internal.