### PR TITLE
BUGFIX: fix phantomjs issue with secure websocket

### DIFF
--- a/salt/control-node/run-testsuite.sh
+++ b/salt/control-node/run-testsuite.sh
@@ -7,5 +7,11 @@ export CLIENT={{ grains.get("client") }}
 export MINION={{ grains.get("minion") }}
 export BROWSER=phantomjs
 
+# phantomjs need suma-server certificate for running secure websockets
+if [ ! -f /etc/pki/trust/anchors/$TESTHOST.cert ]; then
+  wget http://$TESTHOST/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$TESTHOST.cert
+  update-ca-certificates
+fi
+
 cd /root/spacewalk-testsuite-base
 rake


### PR DESCRIPTION
We need to have the suma-server certificate in order to
visualize the button tristate on phantomjs.