### PR TITLE
Add gem for codecoverage ruby

### DIFF
--- a/salt/control-node/init.sls
+++ b/salt/control-node/init.sls
@@ -62,6 +62,7 @@ cucumber-requisites:
       - rubygem-cliver
       - ruby2.1-rubygem-rake
       - rubygem-twopence
+      - ruby2.1-rubygem-simplecov
       - rubygem-lavanda
       - ruby2.1-rubygem-poltergeist
       - ruby2.1-rubygem-rake


### PR DESCRIPTION
This gem packaged in our repo galaxy,
is usefull for find unused steps and analyze code of ruby.
Fix :https://github.com/SUSE/spacewalk-testsuite-base/issues/197