### PR TITLE
update salt and salt-minion - yum does not take dependencies into acc…

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -4,7 +4,9 @@ include:
 
 up-to-date-salt:
   pkg.latest:
-    - name: salt
+    - pkgs:
+      - salt
+      - salt-minion
     - order: last
     - require:
       - sls: default.repos


### PR DESCRIPTION
…ount

yum somehow only update salt but not salt-minion. This change take care that both packages are 
up to date.