### PR TITLE
Adding openscap packages to the minion as well.

### DIFF
--- a/salt/client/repos.sls
+++ b/salt/client/repos.sls
@@ -11,22 +11,11 @@ testsuite-build-repo:
     - require:
       - sls: default
 
-# HACK: this repo should be removed, but we need this packages not otherwise available:
-# "openscap-content", "openscap-extra-probes", "openscap-utils"
-testsuite-suse-manager-repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
-    - source: salt://suse-manager/repos.d/SUSE-Manager-3.0-x86_64-Update.repo
-    - template: jinja
-    - require:
-      - sls: default
-
 refresh-client-repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
     - require:
       - file: testsuite-build-repo
-      - file: testsuite-suse-manager-repo
 
 {% else %}
 

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -11,16 +11,16 @@ cucumber-requisites:
       - spacewalk-check
       - spacewalk-oscap
       - rhncfg-actions
-      - andromeda-dummy 
-      - milkyway-dummy
-      - virgo-dummy
-      - openscap-content
       - openscap-extra-probes
       - openscap-utils
       - man
       - wget
       - adaptec-firmware
       {% if grains['os'] == 'SUSE' %}
+      - openscap-content
+      - andromeda-dummy
+      - milkyway-dummy
+      - virgo-dummy
       - aaa_base-extras
       {% endif %}
     - require:

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -6,11 +6,16 @@ include:
 cucumber-requisites:
   pkg.installed:
     - pkgs:
-      - andromeda-dummy 
-      - milkyway-dummy 
-      - virgo-dummy
       - salt-minion
+      - openscap-extra-probes
+      - openscap-utils
+      {% if grains['os'] == 'SUSE' %}
+      - openscap-content
+      - andromeda-dummy
+      - milkyway-dummy
+      - virgo-dummy
       - aaa_base-extras
+      {% endif %}
     - require:
       - sls: client.repos
 


### PR DESCRIPTION
* Functionality: add openscap packages to the minion as well.
* Cleanup: no more hack to pick repo in suse manager 3.0 for openscap packages.
* Cleanup: get rid of errors about missing packages on centos7.