### PR TITLE
enforce latest libzypp because of bsc#1030919

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -26,6 +26,14 @@ cucumber_requisites:
     - require:
       - sls: client.repos
 
+{% if grains['os_family'] == 'Suse' %}
+enforce_latest_libzypp:
+  pkg.latest:
+    - name: libzypp
+    - require:
+      - sls: client.repos
+{% endif %}
+
 testsuite_authorized_key:
   file.append:
     - name: /root/.ssh/authorized_keys


### PR DESCRIPTION
take care the we run with the latest libzypp.
A fix in apache prevents to use older libzypp.