### PR TITLE
Make Cucumber features runnable from the command line

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -107,6 +107,11 @@ To start the testsuite, use:
 ssh -t root@controller.tf.local run-testsuite
 ```
 
+To run individual Cucumber features, use:
+```
+ssh -t root@controller.tf.local cucumber spacewalk-testsuite-base/features/my_feature.feature
+```
+
 Get HTML results with:
 ```
 scp root@controller.tf.local://root/spacewalk-testsuite-base/output.html .

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -1,0 +1,11 @@
+export SSHMINION={{ grains.get("ssh_minion") }}
+export CENTOSMINION={{ grains.get("centos_minion") }}
+export TESTHOST={{ grains.get("server") }}
+export CLIENT={{ grains.get("client") }}
+export MINION={{ grains.get("minion") }}
+
+# phantomjs need suma-server certificate for running secure websockets
+if [ ! -f /etc/pki/trust/anchors/$TESTHOST.cert ]; then
+  wget http://$TESTHOST/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$TESTHOST.cert
+  update-ca-certificates
+fi

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -87,11 +87,11 @@ cucumber_run_script:
     - group: root
     - mode: 755
 
-env-vars:
-    file.managed:
-        - name: /root/.bashrc
-        - source: salt://controller/bashrc
-        - template: jinja
-        - user: root
-        - group: root
-        - mode: 755
+testsuite_env_vars:
+  file.managed:
+    - name: /root/.bashrc
+    - source: salt://controller/bashrc
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 755

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -86,3 +86,12 @@ cucumber_run_script:
     - user: root
     - group: root
     - mode: 755
+
+env-vars:
+    file.managed:
+        - name: /root/.bashrc
+        - source: salt://controller/bashrc
+        - template: jinja
+        - user: root
+        - group: root
+        - mode: 755

--- a/salt/controller/run-testsuite.sh
+++ b/salt/controller/run-testsuite.sh
@@ -1,16 +1,4 @@
 #!/bin/bash
 
-export SSHMINION={{ grains.get("ssh_minion") }}
-export CENTOSMINION={{ grains.get("centos_minion") }}
-export TESTHOST={{ grains.get("server") }}
-export CLIENT={{ grains.get("client") }}
-export MINION={{ grains.get("minion") }}
-
-# phantomjs need suma-server certificate for running secure websockets
-if [ ! -f /etc/pki/trust/anchors/$TESTHOST.cert ]; then
-  wget http://$TESTHOST/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$TESTHOST.cert
-  update-ca-certificates
-fi
-
 cd /root/spacewalk-testsuite-base
 rake


### PR DESCRIPTION
This change moves environment setup to `.bashrc` for the test controller so that the individual cucumber features can be runnable from the command line as below:

```
cucumber features/my_feature.feature
```