### PR TITLE
Fix: disable GPG check on 3rd-party repos

### DIFF
--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -229,6 +229,7 @@ tools_repo:
     - humanname: {{ label }}
     - baseurl: {{ url }}
     - priority: 98
+    - gpgcheck: 0
 {% endfor %}
 
 default_repos:


### PR DESCRIPTION
A Salt failure during provisioning can happen when using
`additional_repos`, e.g.:

```
protobuf = "http://download.opensuse.org/repositories/home:aplanas:midokura/SLE_12_SP2/"
```

zypper cause this problem, as it asks interactively if repo is trusted:

```
module.minion_improved.minion.libvirt_domain.domain (remote-exec): New repository or package signing key received:
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Repository:       'protobuf'
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Key Name:         home:aplanas OBS Project <home:aplanas@build.opensuse.org>
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Key Fingerprint:  98DB6E85 C50321EA D148EA36 4C078E5A 3A961CF7
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Key Created:      Thu Feb 26 16:19:26 2015
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Key Expires:      Sat May  6 16:19:26 2017 (expires in 23 days)
module.minion_improved.minion.libvirt_domain.domain (remote-exec):   Rpm Name:         gpg-pubkey-3a961cf7-54ef478e
module.minion_improved.minion.libvirt_domain.domain (remote-exec): Do you want to reject the key, trust temporarily, or trust always? [r/t/a/? shows all options] (r): r
```

As per sumaform's design, we do not explicitly care about security, especially
on 3rd-party repos.

This patch disabled GPG check for 3rd party repos.