### PR TITLE
31 repositories

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -5,6 +5,7 @@ variable "images" {
     "3.0-released" = "sles12sp1"
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
+    "3.1-nightly" = "sles12sp2"
     "head" = "sles12sp2"
   }
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 2.1-released,  2.1-nightly, 3.0-nightly, 3.0-released, 3.1-released, head"
+  description = "One of: 2.1-released,  2.1-nightly, 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -5,6 +5,7 @@ variable "images" {
     "3.0-released" = "sles12sp1"
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
+    "3.1-nightly" = "sles12sp2"
     "head" = "sles12sp2"
   }
 }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 2.1-released,  2.1-nightly, 3.0-nightly, 3.0-released, 3.1-released, head"
+  description = "One of: 2.1-released,  2.1-nightly, 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head"
   type = "string"
 }
 

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64]
+name=Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64]
+name=Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64]
+name=Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -50,7 +50,30 @@ os_update_repo:
     - template: jinja
 {% endif %}
 
-{% if 'head' in grains.get('version', '') or '3.1-released' in grains.get('version', '') %}
+
+{% if 'released' in grains.get('version', 'released') %}
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
+    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
+    - template: jinja
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_channel_needed
+{% elif 'nightly' in grains.get('version', '') %}
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
+    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
+    - template: jinja
+
+tools_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
+    - template: jinja
+{% elif 'head' in grains.get('version', '') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
@@ -62,28 +85,6 @@ tools_update_repo:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
     - template: jinja
-{% elif 'nightly' in grains.get('version', '') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - template: jinja
-
-tools_update_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
-    - template: jinja
-{% elif 'released' in grains.get('version', 'released') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - template: jinja
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_channel_needed
 {% endif %}
 
 {% endif %}
@@ -129,27 +130,8 @@ os_update_repo:
     - template: jinja
 {% endif %}
 
-{% if 'head' in grains.get('version', '') or '3.1-released' in grains.get('version', '') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
-    - template: jinja
 
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_channel_needed
-{% elif 'nightly' in grains.get('version', '') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
-    - template: jinja
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_channel_needed
-{% elif 'released' in grains.get('version', 'released') %}
+{% if 'released' in grains.get('version', 'released') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -161,6 +143,29 @@ tools_update_repo:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
+{% elif 'nightly' in grains.get('version', '') %}
+
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_channel_needed
+
+{% elif 'head' in grains.get('version', '') %}
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_channel_needed
+
 {% endif %}
 {% endif %}
 
@@ -201,7 +206,7 @@ tools_pool_repo:
     - template: jinja
     - require:
       - cmd: galaxy_key
-{% if 'head' in grains.get('version', '') or '3.1-released' in grains.get('version', '') %}
+{% if 'head' in grains.get('version', '') %}
 tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
@@ -212,8 +217,8 @@ tools_update_repo:
 {% elif 'nightly' in grains.get('version', '') %}
 tools_update_repo:
   file.managed:
-    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
+    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
     - template: jinja
     - require:
       - cmd: galaxy_key

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -51,40 +51,34 @@ os_update_repo:
 {% endif %}
 
 
-{% if 'released' in grains.get('version', 'released') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
     - template: jinja
 
+{% if 'released' in grains.get('version', 'released') %}
+
 tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_channel_needed
+
 {% elif 'nightly' in grains.get('version', '') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - template: jinja
 
 tools_update_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
     - template: jinja
+
 {% elif 'head' in grains.get('version', '') %}
-tools_pool_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
-    - template: jinja
 
 tools_update_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
     - template: jinja
+
 {% endif %}
 
 {% endif %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -63,6 +63,14 @@ tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_channel_needed
 
+{% elif '3.0-nightly' in grains.get('version', '') %}
+
+tools_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
+    - template: jinja
+
 {% elif 'nightly' in grains.get('version', '') %}
 
 tools_update_repo:
@@ -137,6 +145,19 @@ tools_update_repo:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
+
+{% elif '3.0-nightly' in grains.get('version', '') %}
+
+tools_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_channel_needed
+
 {% elif 'nightly' in grains.get('version', '') %}
 
 tools_pool_repo:
@@ -205,6 +226,14 @@ tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
+    - template: jinja
+    - require:
+      - cmd: galaxy_key
+{% elif '3.0-nightly' in grains.get('version', '') %}
+tools_update_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
     - template: jinja
     - require:
       - cmd: galaxy_key

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -47,6 +47,14 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc
 mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product/
 mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.0/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.0/x86_64/update/
 
+# SUSE Manager 3.1
+mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/
+
+# SUSE Manager 3.1 Proxy
+mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/
+
 # SLE 12 (GA and all SPs) Manager Tools
 mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/
 mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/
@@ -63,14 +71,6 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc
 # mirror --continue --delete --loop --parallel=3 --verbose=3 repo/$RCE/RES7/x86_64/
 
 open http://download.suse.de
-
-# SUSE Manager 3.1
-mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/
-mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/
-
-# SUSE Manager 3.1 Proxy
-mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/
-mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/
 
 # SUSE Manager Head
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -90,6 +90,18 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 # RES 7 Manager Tools 3.0 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/ ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
 
+# SUSE Manager 3.1 devel
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.devel31\.x86_64\.rpm" -i "noarch/.*\.devel31\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/ ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
+
+# SLE 11 (SP3 and SP4) Manager Tools 3.1 devel
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/ ibs/Devel:/Galaxy:/Manager:/3.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/
+
+# SLE 12 (GA and all SPs) Manager Tools 3.1 devel
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/3.1:/SLE12-SUSE-Manager-Tools/images/repo/SLE-12-Manager-Tools-POOL-x86_64-Media1/
+
+# RES 7 Manager Tools 3.1 devel
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/ ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
+
 # SUSE Manager Head devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.develHead\.x86_64\.rpm" -i "noarch/.*\.develHead\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/ ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/
 

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -81,6 +81,9 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 # SUSE Manager 3.0 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.devel30\.x86_64\.rpm" -i "noarch/.*\.devel30\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/3.0/SLE_12_SP1_Update/ ibs/Devel:/Galaxy:/Manager:/3.0/SLE_12_SP1_Update/
 
+# SUSE Manager 3.1 devel
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.devel31\.x86_64\.rpm" -i "noarch/.*\.devel31\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/ ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
+
 # SLE 11 (SP3 and SP4) Manager Tools 3.0 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.0:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/ ibs/Devel:/Galaxy:/Manager:/3.0:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/
 
@@ -89,9 +92,6 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 
 # RES 7 Manager Tools 3.0 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/ ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
-
-# SUSE Manager 3.1 devel
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.devel31\.x86_64\.rpm" -i "noarch/.*\.devel31\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/ ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
 
 # SLE 11 (SP3 and SP4) Manager Tools 3.1 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/ ibs/Devel:/Galaxy:/Manager:/3.1:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-x86_64-i586-Media1/suse/

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -65,10 +65,12 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc
 open http://download.suse.de
 
 # SUSE Manager 3.1
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/ ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/
+mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/
 
 # SUSE Manager 3.1 Proxy
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Proxy-3.1-POOL-x86_64-Media1/ ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Proxy-3.1-POOL-x86_64-Media1/
+mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/
 
 # SUSE Manager Head
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/

--- a/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_3.1.repo
+++ b/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_3.1.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_3.1]
+name=Devel Project for SUSE Manager 3.1 (SLE_12_SP2)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
+priority=98

--- a/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
+++ b/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
@@ -2,4 +2,4 @@
 name=SUSE-Manager-Proxy-3.1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains["mirror"] | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Proxy-3.1-POOL-x86_64-Media1/
+baseurl=http://{{ grains["mirror"] | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product/

--- a/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
+++ b/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SUSE-Manager-Proxy-3.1-x86_64-Update]
+name=SUSE-Manager-Proxy-3.1-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains["mirror"] | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update/

--- a/salt/suse_manager_proxy/repos.sls
+++ b/salt/suse_manager_proxy/repos.sls
@@ -89,6 +89,16 @@ suse_manager_devel_repo:
       - sls: default
 {% endif %}
 
+{% if '3.1-nightly' in grains['version'] %}
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1.repo
+    - source: salt://suse_manager_proxy/repos.d/Devel_Galaxy_Manager_3.1.repo
+    - template: jinja
+    - require:
+      - sls: default
+{% endif %}
+
 {% if 'head' in grains['version'] %}
 suse_manager_devel_repo:
   file.managed:

--- a/salt/suse_manager_proxy/repos.sls
+++ b/salt/suse_manager_proxy/repos.sls
@@ -47,8 +47,12 @@ suse_manager_proxy_pool_repo:
       - sls: default
 
 suse_manager_proxy_update_repo:
-  file.touch:
-    - name: /tmp/no_update_channel_needed
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
+    - source: salt://suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Update.repo
+    - template: jinja
+    - require:
+      - sls: default
 {% endif %}
 
 {% if 'head' in grains['version'] %}

--- a/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_3.1.repo
+++ b/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_3.1.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_3.1]
+name=Devel Project for SUSE Manager 3.1 (SLE_12_SP2)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2/
+priority=98

--- a/salt/suse_manager_server/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
+++ b/salt/suse_manager_server/repos.d/SUSE-Manager-3.1-x86_64-Pool.repo
@@ -2,4 +2,4 @@
 name=SUSE-Manager-3.1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP2:/Update:/Products:/Manager31/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.1/x86_64/product

--- a/salt/suse_manager_server/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
+++ b/salt/suse_manager_server/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SUSE-Manager-3.1-x86_64-Update]
+name=SUSE-Manager-3.1-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.1/x86_64/update/

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -97,6 +97,16 @@ suse_manager_devel_repo:
       - sls: default
 {% endif %}
 
+{% if '3.1-nightly' in grains['version'] %}
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1.repo
+    - source: salt://suse_manager_server/repos.d/Devel_Galaxy_Manager_3.1.repo
+    - template: jinja
+    - require:
+      - sls: default
+{% endif %}
+
 {% if 'oracle' in grains['database'] %}
 suse_manager_oracle_repo:
   file.managed:

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -47,8 +47,12 @@ suse_manager_pool_repo:
       - sls: default
 
 suse_manager_update_repo:
-  file.touch:
-    - name: /tmp/no_update_channel_needed
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
+    - source: salt://suse_manager_server/repos.d/SUSE-Manager-3.1-x86_64-Update.repo
+    - template: jinja
+    - require:
+      - sls: default
 {% endif %}
 
 {% if 'head' in grains['version'] %}


### PR DESCRIPTION
Some version fixes, URL changes and introduce 3.1-nightly version since we have the 
needed Devel repos for it.

salt/default/repos.sls :

I re-ordered the Tools repos creation:

1. check for any "released" string in the grains. Also used when no version is specified
2. check for any "nightly" string in the grains.
3. check for "head"

For me this makes it easier to understand as the current ordering.


