### PR TITLE
Fix: add empty else branch

### DIFF
--- a/salt/suse_manager_server/rhn.sls
+++ b/salt/suse_manager_server/rhn.sls
@@ -80,7 +80,7 @@ create_activation_key:
 
 create_bootstrap_script:
   cmd.run:
-    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date {{'--traditional' if '2.1' not in grains['version'] and '3.0' not in grains['version']}}
+    - name: rhn-bootstrap --activation-keys=1-DEFAULT --no-up2date {{ '--traditional' if '2.1' not in grains['version'] and '3.0' not in grains['version'] else '' }}
     - creates: /srv/www/htdocs/pub/bootstrap/bootstrap.sh
     - require:
       - cmd: create_activation_key


### PR DESCRIPTION
This PR fixes a bug introduced in `8726bc9`, where Jinja complains about a
missing else:

```
module.suma3pg.suse_manager.libvirt_domain.domain (remote-exec): local:
module.suma3pg.suse_manager.libvirt_domain.domain (remote-exec):     Data failed to compile:
module.suma3pg.suse_manager.libvirt_domain.domain (remote-exec): ----------
module.suma3pg.suse_manager.libvirt_domain.domain (remote-exec):     Rendering SLS 'base:suse_manager_server.rhn' failed: Jinja variable the inline if-expression on line 83 evaluated to false and no else section was defined.
```

This PR will add an empty else branch in order to pass compilation phase for
Jinja.