### PR TITLE
Installing "salt-ssh" cli on suma server (for testsuite only)

### DIFF
--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -102,6 +102,11 @@ expect:
 aaa_base-extras:
   pkg.installed
 
+salt-ssh:
+  pkg.installed:
+    - require:
+      - sls: suse_manager_server.repos
+
 enable_salt_content_staging_window:
   file.replace:
     - name: /usr/share/rhn/config-defaults/rhn_java.conf


### PR DESCRIPTION
This PR installs `salt-ssh` CLI on the SUMA server (for testsuite only) since it's now required by `spacewalk-testsuite-base` to check rendered pillar data for ssh minions.