### PR TITLE
disable gpgcheck for RES repos. GPG key is not installed on our image

### DIFF
--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64.repo
@@ -2,5 +2,6 @@
 name=Devel_Galaxy_Manager_3.0_RES-Manager-Tools-7-x86_64
 type=rpm-md
 enabled=1
+gpgcheck=0
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.0:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
 priority=98

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
@@ -2,4 +2,5 @@
 name=Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64
 type=rpm-md
 enabled=1
+gpgcheck=0
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/

--- a/salt/default/repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
@@ -2,5 +2,6 @@
 name=Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64
 type=rpm-md
 enabled=1
+gpgcheck=0
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-RES-7-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-RES-7-x86_64.repo
@@ -2,4 +2,5 @@
 name=SLE-Manager-Tools-RES-7-x86_64
 type=rpm-md
 enabled=1
+gpgcheck=0
 baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build-ncc.suse.de/SUSE/Updates/RES/7-CLIENT-TOOLS/x86_64/update/


### PR DESCRIPTION
sumaform do not setup centos correct. It failed to update salt-minion package to new version because the
GPG key is not installed on the image.

Disable GPG check for these repos.