### PR TITLE
Change salt 'file_root' for sumaform to /opt/sumaform/srv/salt

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -187,3 +187,7 @@ A simple solution is to create a symbolic link pointing to the `salt` directory 
 The error means that there is no such version as "3-stable" for the desired resource. Specifically, all SUSE Manager 3.0 versions have been renamed to get a `3.0-` prefix instead of the old `3-` one to avoid confusion with 3.1, moreover `stable` has been replaced by `released` to take into account beta versions.
 
 In this specific example, use `3.0-released` instead of `3-stable`. In other cases, please check the `variables.tf` file of the module you want to use.
+
+## Q: how do I re-apply the Salt state that was used to provision the machine?
+
+Run `salt-call --local --file-root=/root/salt state.highstate`.

--- a/modules/aws/evil_minions/main.tf
+++ b/modules/aws/evil_minions/main.tf
@@ -33,7 +33,7 @@ resource "null_resource" "host_salt_configuration" {
 
   provisioner "file" {
     source = "salt"
-    destination = "/srv/salt"
+    destination = "/root"
   }
 
   provisioner "file" {
@@ -62,8 +62,8 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "salt-call --local --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --force-color --local state.highstate"
+      "salt-call --local --file-root=/root/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/root/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -33,9 +33,15 @@ resource "null_resource" "host_salt_configuration" {
     bastion_host = "${var.mirror_public_name}"
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /opt/sumaform/srv"
+    ]
+  }
+
   provisioner "file" {
     source = "salt"
-    destination = "/srv/salt"
+    destination = "/opt/sumaform/srv"
   }
 
   provisioner "file" {
@@ -69,8 +75,8 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "salt-call --local --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --force-color --local state.highstate"
+      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -33,15 +33,9 @@ resource "null_resource" "host_salt_configuration" {
     bastion_host = "${var.mirror_public_name}"
   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "mkdir -p /opt/sumaform/srv"
-    ]
-  }
-
   provisioner "file" {
     source = "salt"
-    destination = "/opt/sumaform/srv"
+    destination = "/root"
   }
 
   provisioner "file" {
@@ -75,8 +69,8 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --force-color state.highstate"
+      "salt-call --local --file-root=/root/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/root/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/aws/minionswarm/main.tf
+++ b/modules/aws/minionswarm/main.tf
@@ -33,7 +33,7 @@ resource "null_resource" "host_salt_configuration" {
 
   provisioner "file" {
     source = "salt"
-    destination = "/srv/salt"
+    destination = "/root"
   }
 
   provisioner "file" {
@@ -62,8 +62,8 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "salt-call --local --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --force-color --local state.highstate"
+      "salt-call --local --file-root=/root/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/root/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/aws/mirror/main.tf
+++ b/modules/aws/mirror/main.tf
@@ -72,7 +72,7 @@ resource "null_resource" "mirror_salt_configuration" {
 
   provisioner "file" {
     source = "salt"
-    destination = "/srv/salt"
+    destination = "/root"
   }
 
   provisioner "file" {
@@ -98,8 +98,8 @@ EOF
 
   provisioner "remote-exec" {
     inline = [
-      "salt-call --local --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --force-color --local state.highstate"
+      "salt-call --local --file-root=/root/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/root/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -38,9 +38,15 @@ resource "libvirt_domain" "domain" {
     password = "linux"
   }
 
+  provisioner "remote-exec" {
+    inline = [
+      "mkdir -p /opt/sumaform/srv"
+    ]
+  }
+
   provisioner "file" {
     source = "salt"
-    destination = "/srv"
+    destination = "/opt/sumaform/srv"
   }
 
   provisioner "file" {
@@ -64,8 +70,8 @@ EOF
   provisioner "remote-exec" {
     inline = [
       "test -e /etc/fstab || touch /etc/fstab",
-      "salt-call --local --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --force-color --local state.highstate"
+      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --force-color state.highstate"
     ]
   }
 }

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -38,15 +38,9 @@ resource "libvirt_domain" "domain" {
     password = "linux"
   }
 
-  provisioner "remote-exec" {
-    inline = [
-      "mkdir -p /opt/sumaform/srv"
-    ]
-  }
-
   provisioner "file" {
     source = "salt"
-    destination = "/opt/sumaform/srv"
+    destination = "/root"
   }
 
   provisioner "file" {
@@ -70,8 +64,8 @@ EOF
   provisioner "remote-exec" {
     inline = [
       "test -e /etc/fstab || touch /etc/fstab",
-      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --output=quiet state.sls_id minimal_package_update default",
-      "salt-call --local --file-root=/opt/sumaform/srv/salt/ --force-color state.highstate"
+      "salt-call --local --file-root=/root/salt/ --output=quiet state.sls_id minimal_package_update default",
+      "salt-call --local --file-root=/root/salt/ --force-color state.highstate"
     ]
   }
 }


### PR DESCRIPTION
This PR applies the new `terraform-post-resource` state at the end of a resource deployment for libvirt and aws modules in order to manage cleanup tasks:

- Remove all files from /srv/salt/
- Remove Salt package from traditional clients

I'm using `at` to trigger the cleanups because otherwise Salt would fail during `terraform-post-resource` execution as jinja template and salt itself would disappear at execution time.