### PR TITLE
Feat: specify email address 'from' to use in SUMa

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -320,20 +320,19 @@ module "sumaheadpg" {
 
 ## Emails
 
-With the default configuration, whenever we bring up a SUMa machine,
+With the default configuration, whenever we bring up a SUSE Manager machine,
 `rhn.conf` is instructed to use root@`hostname -d` as the email sender.
-Emails are then using `root@tf.local`, which may be discarded by the
-recipient's SMTP server due to being a non-existent domain.
+The recipient's SMTP server may discard those emails since they come from a non-existent domain name.
 
-With this PR we can override email address to use as 'from' by
+We can override email address to use as 'from' by
 supplying the parameter: `from_email`. E.g.:
 
 ```
-module "sumamail2" {
+module "suma3pg" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
 
-  name = "sumamail2"
+  name = "suma3pg"
   version = "head"
 
   from_email = "root@mbologna.openvpn.suse.de"

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -318,14 +318,11 @@ module "sumaheadpg" {
 }
 ```
 
-## Emails
+## E-mail configuration
 
-With the default configuration, whenever we bring up a SUSE Manager machine,
-`rhn.conf` is instructed to use root@`hostname -d` as the email sender.
-The recipient's SMTP server may discard those emails since they come from a non-existent domain name.
+With the default configuration, whenever SUSE Manager server hosts are configured to use root@`hostname -d` as the email sender. The recipient's SMTP server may discard those emails since they come from a non-existent domain name.
 
-We can override email address to use as 'from' by
-supplying the parameter: `from_email`. E.g.:
+This setting can be overridden with a custom 'from' address by supplying the parameter: `from_email`. A libvirt example would be:
 
 ```
 module "suma3pg" {

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -317,3 +317,25 @@ module "sumaheadpg" {
   use_unreleased_updates = true
 }
 ```
+
+## Emails
+
+With the default configuration, whenever we bring up a SUMa machine,
+`rhn.conf` is instructed to use root@`hostname -d` as the email sender.
+Emails are then using `root@tf.local`, which may be discarded by the
+recipient's SMTP server due to being a non-existent domain.
+
+With this PR we can override email address to use as 'from' by
+supplying the parameter: `from_email`. E.g.:
+
+```
+module "sumamail2" {
+  source = "./modules/libvirt/suse_manager"
+  base_configuration = "${module.base.configuration}"
+
+  name = "sumamail2"
+  version = "head"
+
+  from_email = "root@mbologna.openvpn.suse.de"
+}
+```

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -37,6 +37,7 @@ for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
 monitored: ${var.monitored}
+suma_email_from: ${var.suma_email_from}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -37,7 +37,7 @@ for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
 monitored: ${var.monitored}
-suma_email_from: ${var.suma_email_from}
+from_email: ${var.suma_email_from}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -37,7 +37,7 @@ for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
 monitored: ${var.monitored}
-from_email: ${var.suma_email_from}
+from_email: ${var.from_email}
 
 EOF
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -48,7 +48,7 @@ variable "use_unreleased_updates" {
   default = false
 }
 
-variable "suma_email_from" {
+variable "from_email" {
   description = "email address used in SUMa as sender for emails"
   default = "null"
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -49,7 +49,7 @@ variable "use_unreleased_updates" {
 }
 
 variable "from_email" {
-  description = "email address used in SUMa as sender for emails"
+  description = "email address used as sender for emails"
   default = "null"
 }
 

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -48,6 +48,11 @@ variable "use_unreleased_updates" {
   default = false
 }
 
+variable "suma_email_from" {
+  description = "email address used in SUMa as sender for emails"
+  default = "null"
+}
+
 variable "smt" {
   description = "URL to an SMT server to get packages from"
   default = "null"

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -97,3 +97,13 @@ no_motd:
     - name: /etc/motd
     - require:
       - cmd: suse_manager_setup
+
+{% if grains['suma_email_from'] %}
+substitute_email_sender_address:
+  file.replace:
+    - name: /etc/rhn/rhn.conf
+    - pattern: web.default_mail_from.*
+    - repl: web.default_mail_from = {{ grains.get('suma_email_from') }}
+    - require:
+        - cmd: suse_manager_setup
+{% endif %}

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -98,12 +98,12 @@ no_motd:
     - require:
       - cmd: suse_manager_setup
 
-{% if grains['suma_email_from'] %}
+{% if grains['from_email'] %}
 substitute_email_sender_address:
   file.replace:
     - name: /etc/rhn/rhn.conf
     - pattern: web.default_mail_from.*
-    - repl: web.default_mail_from = {{ grains.get('suma_email_from') }}
+    - repl: web.default_mail_from = {{ grains.get('from_email') }}
     - require:
         - cmd: suse_manager_setup
 {% endif %}


### PR DESCRIPTION
With the default configuration, whenever we bring up a SUMa machine,
`rhn.conf` is instructed to use root@`hostname -d` as the email sender.
Emails are then using `root@tf.local`, which may be discarded by the
recipient's SMTP server due to being a non-existent domain.

With this PR we can override email address to use as 'from' by
supplying the parameter: `suma_email_from`. E.g.:

```
module "sumamail2" {
  source = "./modules/libvirt/suse_manager"
  base_configuration = "${module.base.configuration}"

  name = "sumamail2"
  version = "head"

  suma_email_from = "root@mbologna.openvpn.suse.de"
}
```