### PR TITLE
Bugfix: avoid VMs to be created before base images are ready

### DIFF
--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -10,6 +10,7 @@ resource "libvirt_volume" "volumes" {
 }
 
 output "configuration" {
+  depends_on = ["libvirt_volume.volumes"]
   value = {
     network_name = "${var.network_name}"
     cc_username = "${var.cc_username}"


### PR DESCRIPTION
Should address #74, has been reproduced and tested by a colleague