### PR TITLE
Name /etc/sysconfig/SuSEfirewall2 variables

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -75,6 +75,11 @@ Could not resolve hostname suma3pg.tf.local: Name or service not known
 Check that:
  - your firewall is not blocking UDP port 5353
    - on SUSE systems check YaST -> Security and Users -> Firewall -> Allowed Services, "Zeroconf/Bonjour Multicast DNS" should either appear on the list or be added
+   
+   or
+   
+   - edit `/etc/sysconfig/SuSEfirewall2` and add `mdns` to `FW_SERVICES_DMZ_UDP`
+     (assuming that your bridge interface is in `FW_DEV_DMZ`)
  - avahi is installed and running
    - typically you can check this via systemd: `systemctl status avahi-daemon`
  - mdns is configured in glibc's Name Server Switch configuration file


### PR DESCRIPTION
If you don't have YaST, edit /etc/sysconfig/SuSEfirewall2 to enable mdns