### PR TITLE
Fix: make salt-ssh hosts really vanilla hosts

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -47,7 +47,7 @@ module "head-min-sles12sp2" {
 }
 
 module "head-minssh-sles12sp2" {
-  source = "./modules/libvirt/minion"
+  source = "./modules/libvirt/host"
   base_configuration = "${module.base.configuration}"
   version = "head"
   name = "head-minssh-sles12sp2"

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -23,6 +23,7 @@ module "head-srv" {
   version = "head"
   for_development_only = false
   for_testsuite_only = true
+  ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
 module "head-cli-sles12sp2" {
@@ -33,6 +34,7 @@ module "head-cli-sles12sp2" {
   server_configuration =  { hostname = "head-srv.tf.local" }
   for_development_only = false
   for_testsuite_only = true
+  ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
 module "head-min-sles12sp2" {
@@ -44,17 +46,15 @@ module "head-min-sles12sp2" {
   server_configuration = { hostname = "head-srv.tf.local" }
   for_development_only = false
   for_testsuite_only = true
+  ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
 module "head-minssh-sles12sp2" {
   source = "./modules/libvirt/host"
   base_configuration = "${module.base.configuration}"
-  version = "head"
   name = "head-minssh-sles12sp2"
   image = "sles12sp2"
-  server_configuration = { hostname = "head-srv.tf.local" }
-  for_development_only = false
-  for_testsuite_only = true
+  ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
 module "head-min-centos7" {

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -30,7 +30,7 @@
 All machines come with avahi's mDNS configured by default on the `.tf.local` domain, and a `root` user with password `linux`.
 Upon provisioning your SSH public key (by default `~/.ssh/id_rsa.pub`) is copied into the remote machine. This means that you can access every machine without supplying any password.
 
-If you want to use another key, specify the path of the public key with `ssh_key_path` into the `base` config. Example:
+If you want to use another key for all VMs, specify the path of the public key with `ssh_key_path` into the `base` config. Example:
 
 ```hcl
 module "base" {
@@ -40,8 +40,7 @@ module "base" {
 }
 ```
 
-`ssh_key_path` option can also be specified on a per-host basis. In this case, the key specified is an additional key,
-copied to the machine as well as the `ssh_key_path` specified in the `base` section.
+The `ssh_key_path` option can also be specified on a per-host basis. In this case, the key specified is treated as an additional key, copied to the machine as well as the `ssh_key_path` specified in the `base` section.
 
 If you don't want to copy any ssh key at all (and use passwords instead), just supply an empty file (eg. `ssh_key_path = "/dev/null"`).
 

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -40,6 +40,9 @@ module "base" {
 }
 ```
 
+`ssh_key_path` option can also be specified on a per-host basis. In this case, the key specified is an additional key,
+copied to the machine as well as the `ssh_key_path` specified in the `base` section.
+
 If you don't want to copy any ssh key at all (and use passwords instead), just supply an empty file (eg. `ssh_key_path = "/dev/null"`).
 
 Provided your host is on the same network segment of the virtual machines you can access them via:

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -10,6 +10,7 @@ module "client" {
   mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -72,3 +72,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default = ""
+}

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -52,7 +52,7 @@ use_avahi: ${var.base_configuration["use_avahi"]}
 timezone: ${var.base_configuration["timezone"]}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
-authorized_keys: ${file(var.base_configuration["ssh_key_path"])}
+authorized_keys: [${var.ssh_key_path == "" ? "${trimspace(file(var.base_configuration["ssh_key_path"]))}" : "${trimspace(file(var.base_configuration["ssh_key_path"]))}, ${trimspace(file(var.ssh_key_path))}"}]
 reset_ids: true
 ${var.grains}
 

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -57,3 +57,8 @@ variable "grains" {
   description = "custom grain string to be added to this host's configuration"
   default = ""
 }
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default = "/dev/null" # we cannot use "": terraform tries to open this file at host/main.tf:55
+}

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -10,6 +10,7 @@ module "minion" {
   mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -72,3 +72,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default = ""
+}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -23,6 +23,7 @@ module "suse_manager" {
   mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
 version: ${var.version}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -107,3 +107,8 @@ variable "traceback_email" {
   description = "recipient email address that will receive errors during usage"
   default = "null"
 }
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default = ""
+}

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -33,10 +33,4 @@ enforce_latest_libzypp:
     - require:
       - sls: client.repos
 {% endif %}
-
-testsuite_authorized_key:
-  file.append:
-    - name: /root/.ssh/authorized_keys
-    - source: salt://controller/id_rsa.pub
-    - makedirs: True
 {% endif %}

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -50,8 +50,13 @@ update_sles_test:
   pkg.uptodate
 {% endif %}
 
+{% if grains['authorized_keys'] %}
 authorized_keys:
   file.append:
     - name: /root/.ssh/authorized_keys
-    - text: {{ salt["grains.get"]("authorized_keys") }}
+    - text:
+{% for key in grains['authorized_keys'] %}
+      - {{ key }}
+{% endfor %}
     - makedirs: True
+{% endif %}

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -19,12 +19,6 @@ cucumber_requisites:
     - require:
       - sls: minion.repos
 
-testsuite_authorized_key:
-  file.append:
-    - name: /root/.ssh/authorized_keys
-    - source: salt://controller/id_rsa.pub
-    - makedirs: True
-
 {% if grains['os'] == 'SUSE' and grains['osrelease'] == '12.2' %}
 
 certificates:

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -4,12 +4,6 @@ include:
   - suse_manager_server
   - suse_manager_server.repos
 
-testsuite_authorized_key:
-  file.append:
-    - name: /root/.ssh/authorized_keys
-    - source: salt://controller/id_rsa.pub
-    - makedirs: True
-
 anaconda_package_file:
   file.managed:
     - name: /root/anaconda-18.37.11-1.fc18.x86_64.rpm


### PR DESCRIPTION
If an host is marked as salt-ssh bootstrapped, we should use its vanilla option.
This needs testing.
@MalloZup @Bischoff 