### PR TITLE
Fix: restore pkg dependency to postgresql94

### DIFF
--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -27,10 +27,6 @@ postgresql-fixed-version-workaround:
       - postgresql94
       - postgresql94-server
       - postgresql94-contrib
-
-postgresql-lock-packages:
-  cmd.run:
-    - name: zypper al postgresql
 {% endif %}
 
 suse_manager_packages:
@@ -83,7 +79,6 @@ suse_manager_packages:
       - sls: suse_manager_server.firewall
       {% if '3.0-released' in grains['version'] %}
       - pkg: postgresql-fixed-version-workaround
-      - cmd: postgresql-lock-packages
       {% endif %}
 
 environment_setup_script:
@@ -102,7 +97,7 @@ uninstall-postgres-96:
     - pkgs:
       - postgresql96
       - postgresql-init: 9.6
-      - postgresql96-contrib-9.6
+      - postgresql96-contrib
       - postgresql96-server
 {% endif %}
 

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -86,9 +86,9 @@ environment_setup_script:
     - name: /root/setup_env.sh
     - source: salt://suse_manager_server/setup_env.sh
     - template: jinja
-  require:
     {% if '3.0-released' in grains['version'] %}
-    - pkg: uninstall-postgres-96
+    - require:
+      - pkg: uninstall-postgres-96
     {% endif %}
 
 {% if '3.0-released' in grains['version'] %}

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -19,6 +19,20 @@ sles_release_fix:
       - sls: suse_manager_server.repos
 {% endif %}
 
+{% if '3.0-released' in grains['version'] %}
+postgresql-fixed-version-workaround:
+  pkg.installed:
+    - pkgs:
+      - postgresql-init: 9.4
+      - postgresql94
+      - postgresql94-server
+      - postgresql94-contrib
+
+postgresql-lock-packages:
+  cmd.run:
+    - name: zypper al postgresql
+{% endif %}
+
 suse_manager_packages:
   pkg.latest:
     {% if 'head' in grains['version'] %}
@@ -67,12 +81,30 @@ suse_manager_packages:
     - require:
       - sls: suse_manager_server.repos
       - sls: suse_manager_server.firewall
+      {% if '3.0-released' in grains['version'] %}
+      - pkg: postgresql-fixed-version-workaround
+      - cmd: postgresql-lock-packages
+      {% endif %}
 
 environment_setup_script:
   file.managed:
     - name: /root/setup_env.sh
     - source: salt://suse_manager_server/setup_env.sh
     - template: jinja
+  require:
+    {% if '3.0-released' in grains['version'] %}
+    - pkg: uninstall-postgres-96
+    {% endif %}
+
+{% if '3.0-released' in grains['version'] %}
+uninstall-postgres-96:
+  pkg.removed:
+    - pkgs:
+      - postgresql96
+      - postgresql-init: 9.6
+      - postgresql96-contrib-9.6
+      - postgresql96-server
+{% endif %}
 
 suse_manager_setup:
   cmd.run:


### PR DESCRIPTION
Restore dependency to postgresql94 in 3.0-released version as a workaround fix.