### PR TITLE
Feat: autoselect testsuite branch

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -142,7 +142,7 @@ Please note that `iss_master` is set from `suma21pgm`'s module output variable `
 
 It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the main.tf.libvirt-testsuite.example file. This will create a test server, client and minion instances, plus a coordination node called a `controller` which runs the testsuite.
 
-You can select a branch of the Cucumber testsuite git repo via the `branch` variable in the `controller`, default is `manager30` for the SUSE Manager 3.0 testsuite.
+You can select [a branch of the Cucumber testsuite git repo](https://github.com/SUSE/spacewalk-testsuite-base/blob/master/docs/branches.md) via the `branch` variable in the `controller`. If nothing is specified, an automatic selection of the correct branch will be used, [according to this map](https://github.com/moio/sumaform/blob/1ba9238fd5891ef380401065410f5dce894e6766/modules/libvirt/controller/main.tf#L1-L9).
 
 To start the testsuite, use:
 

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -72,7 +72,6 @@ module "controller" {
   source = "./modules/libvirt/controller"
   base_configuration = "${module.base.configuration}"
   name = "controller"
-  branch = "master"
   server_configuration = "${module.sumaheadpg.configuration}"
   client_configuration = "${module.clisles12sp2.configuration}"
   minion_configuration = "${module.minsles12sp2.configuration}"

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -77,7 +77,5 @@ module "controller" {
   minion_configuration = "${module.minsles12sp2.configuration}"
   centos_configuration = "${module.mincentos7.configuration}"
   minionssh_configuration = "${module.minsles12sp1ssh.configuration}"
-  # branch = "master"
-  # There is a default selection if nothing is specified.
-  # See modules/libvirt/controller/variables.tf for possible values
+  # branch = "master" # See modules/libvirt/controller/variables.tf for possible values
 }

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -77,4 +77,7 @@ module "controller" {
   minion_configuration = "${module.minsles12sp2.configuration}"
   centos_configuration = "${module.mincentos7.configuration}"
   minionssh_configuration = "${module.minsles12sp1ssh.configuration}"
+  # branch = "master"
+  # There is a default selection if nothing is specified.
+  # See modules/libvirt/controller/variables.tf for possible values
 }

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -1,3 +1,13 @@
+variable "testsuite-branch" {
+  default = {
+    "3.0-released" = "manager30"
+    "3.0-nightly" = "manager30"
+    "3.1-released" = "manager31"
+    "3.1-nightly" = "manager31"
+    "head" = "master"
+  }
+}
+
 module "controller" {
   source = "../host"
   base_configuration = "${var.base_configuration}"
@@ -17,6 +27,6 @@ minion: ${var.minion_configuration["hostname"]}
 centos_minion: ${var.centos_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
-branch : ${var.branch}
+branch: ${lookup(var.testsuite-branch, var.server_configuration["version"])}
 EOF
 }

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -27,6 +27,6 @@ minion: ${var.minion_configuration["hostname"]}
 centos_minion: ${var.centos_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
-branch: ${lookup(var.testsuite-branch, var.server_configuration["version"])}
+branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["version"]) : var.branch}
 EOF
 }

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -19,9 +19,8 @@ variable "client_configuration" {
 }
 
 variable "branch" {
-  description = "One of: manager30, master, manager31"
-  type = "string"
-  default = "manager30"
+  description = "Leave default for automatic selection or specify an existing branch of spacewalk-testsuite-base"
+  default = "default"
 }
 
 variable "minion_configuration" {

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -44,5 +44,9 @@ EOF
 }
 
 output "configuration" {
-  value = "${module.suse_manager.configuration}"
+  value {
+    id = "${module.suse_manager.configuration["id"]}"
+    hostname = "${module.suse_manager.configuration["hostname"]}"
+    version = "${var.version}"
+  }
 }

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -67,13 +67,12 @@ cucumber_requisites:
       - sls: controller.repos
 
 cucumber_testsuite:
-  cmd.run:
-    # HACK: work around the lack of skip_verify and enforce_toplevel in archive.extracted before salt 2016.11
-    - name: |
-        wget -P /root/ https://github.com/SUSE/spacewalk-testsuite-base/archive/{{ grains.get("branch" )}}.zip
-        unzip /root/{{ grains.get("branch" )}}.zip -d /root/
-        mv /root/spacewalk-testsuite-base-{{ grains.get("branch" )}} /root/spacewalk-testsuite-base
-    - creates: /root/spacewalk-testsuite-base
+  git.latest:
+    - name: https://github.com/SUSE/spacewalk-testsuite-base
+    - branch: {{ grains.get("branch") }}
+    - target: /root/spacewalk-testsuite-base
+    - require:
+      - pkg: cucumber_requisites
 
 cucumber_run_script:
   file.managed:


### PR DESCRIPTION
Based on the version of the server we are going to launch the testsuite
against, we decide automatically which branch of the testsuite to
checkout.
The association is done in the map defined in:

`modules/libvirt/controller/main.tf`

@MalloZup @Bischoff 