### PR TITLE
The Head Pool repo changed the version to 3.2

### DIFF
--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -88,7 +88,7 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP2:/x86_64/update/ ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP2:/x86_64/update/
 
 # SUSE Manager Head
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/
 
 # SUSE Manager 2.1 devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/2.1/SLE_11_SP3/ ibs/Devel:/Galaxy:/Manager:/2.1/SLE_11_SP3/

--- a/salt/suse_manager_server/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
+++ b/salt/suse_manager_server/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=SUSE-Manager-Head-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.1-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/
 priority=97


### PR DESCRIPTION
I switched the version in Head to 3.2. These changes are needed to keep things working

@moio @MalloZup : I hope I did not forget anything. The new repos are currently building. Expect some trouble :-)