### PR TITLE
TOMCAT_CFG_LOADED flag only for 3.1 version or later

### DIFF
--- a/salt/suse_manager_server/tomcat.sls
+++ b/salt/suse_manager_server/tomcat.sls
@@ -65,7 +65,7 @@ tomcat_config:
     - require:
       - sls: suse_manager_server.rhn
 
-{% if '2.1' not in grains['version'] %}
+{% if '2.1' not in grains['version'] and '3.0' not in grains['version'] %}
 tomcat_config_loaded:
   file.comment:
     - name: /etc/tomcat/tomcat.conf


### PR DESCRIPTION
TOMCAT_CFG_LOADED is not present for older version `[2.1, 3.0]`.