### PR TITLE
Fix - install galaxy.key on all systems

### DIFF
--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -1,5 +1,3 @@
-{% if grains['os'] == 'SUSE' %}
-
 galaxy_key:
   file.managed:
     - name: /tmp/galaxy.key
@@ -8,6 +6,8 @@ galaxy_key:
     - name: rpm --import /tmp/galaxy.key
     - watch:
       - file: galaxy_key
+
+{% if grains['os'] == 'SUSE' %}
 
 {% if grains['osrelease'] == '42.2' %}
 os_pool_repo:


### PR DESCRIPTION
Fix installing galaxy.key on all systems, not just SUSE