### PR TITLE
Filebeat: remove environment references

### DIFF
--- a/salt/suse_manager_server/filebeat.yml
+++ b/salt/suse_manager_server/filebeat.yml
@@ -1,10 +1,6 @@
 filebeat:
   shutdown_timeout: 0
-  name: "${JOB_NAME:${HOSTNAME}}"
-  index: "${JOB_NAME:${HOSTNAME}}-${BUILD_ID:0}"
-  fields: { build: "${BUILD_ID:0}", job: "${JOB_NAME}" }
-  fields_under_root: true
-
+  # name: defaults to hostname
   prospectors:
     -
       paths:
@@ -60,9 +56,7 @@ output:
   logstash:
     # see also logstash/input.conf
     hosts: ["{{ grains.get("log_server") }}"]
-    index: "${JOB_NAME:${HOSTNAME}}-${BUILD_ID:0}"
-    fields: { build: "${BUILD_ID:0}", job: "${JOB_NAME}" }
-    fields_under_root: true
+    index: "%{filebeat.name}-%{+yyyy-MM-dd}"
 
 shipper:
 

--- a/salt/suse_manager_server/filebeat.yml
+++ b/salt/suse_manager_server/filebeat.yml
@@ -4,7 +4,7 @@ filebeat:
   index: "${JOB_NAME:${HOSTNAME}}-${BUILD_ID:0}"
   fields: { build: "${BUILD_ID:0}", job: "${JOB_NAME}" }
   fields_under_root: true
-  path.data: /var/lib/filebeat
+
   prospectors:
     -
       paths:


### PR DESCRIPTION
filebeat fails to start on suse manager server because filebeat.yml cannot be evaluated.

These environment variables only exists on a jenkins node. SUSE Manager server is not a jenkins node, only the sumaform control node is.