### PR TITLE
filebeat: drop date from index, use hostname

### DIFF
--- a/salt/suse_manager_server/filebeat.yml
+++ b/salt/suse_manager_server/filebeat.yml
@@ -56,7 +56,7 @@ output:
   logstash:
     # see also logstash/input.conf
     hosts: ["{{ grains.get("log_server") }}"]
-    index: "%{[beat.name]}-%{+yyyy-MM-dd}"
+    index: "%{[beat.hostname]}"
 
 shipper:
 


### PR DESCRIPTION
The date expression is being added by logstash, filebeat cannot cope with that.
Also use the hostname as the index basename.