### PR TITLE
[WIP] Deepsea integration

### DIFF
--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -67,8 +67,11 @@ variable "image_locations" {
     sles11sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp3.x86_64.qcow2"
     sles11sp4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
     sles12 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
-    sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
+    # sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
     sles12sp2 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
+    # sles12sp1 = "http://download.suse.de/ibs/home:/mdinca:/branches:/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64-1.0.0-Build13.1.qcow2"
+    # sles12sp1 = "/home/mdinca/store/osc_projects/Devel:Galaxy:Terraform:Images/sles12sp1/target/sles12sp1.x86_64-1.0.0.qcow2"
+    sles12sp1 = "/home/store/sles12sp1-2.qcow2"
   }
   type = "map"
 }

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -69,8 +69,6 @@ variable "image_locations" {
     sles12 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
     # sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
     sles12sp2 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
-    # sles12sp1 = "http://download.suse.de/ibs/home:/mdinca:/branches:/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64-1.0.0-Build13.1.qcow2"
-    # sles12sp1 = "/home/mdinca/store/osc_projects/Devel:Galaxy:Terraform:Images/sles12sp1/target/sles12sp1.x86_64-1.0.0.qcow2"
     sles12sp1 = "/home/store/sles12sp1-2.qcow2"
   }
   type = "map"

--- a/modules/libvirt/deepsea/main.tf
+++ b/modules/libvirt/deepsea/main.tf
@@ -1,10 +1,3 @@
-resource "libvirt_volume" "storage" {
-  name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-storage"
-  size = 5120000000
-  pool = "${var.base_configuration["pool"]}"
-  count = "${var.count}"
-}
-
 module "deepsea-minion" {
   source = "../host"
   base_configuration = "${var.base_configuration}"
@@ -17,11 +10,7 @@ module "deepsea-minion" {
   mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
-  additional_disk = ["${concat(
-    list(
-      map("volume_id", "${element(libvirt_volume.storage.*.id, count.index)}")
-    )
-  )}"]
+
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/libvirt/deepsea/main.tf
+++ b/modules/libvirt/deepsea/main.tf
@@ -14,6 +14,7 @@ module "deepsea-minion" {
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
+deepsea: True
 version: ${var.version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}

--- a/modules/libvirt/deepsea/main.tf
+++ b/modules/libvirt/deepsea/main.tf
@@ -1,0 +1,40 @@
+resource "libvirt_volume" "storage" {
+  name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-storage"
+  size = 5120000000
+  pool = "${var.base_configuration["pool"]}"
+  count = "${var.count}"
+}
+
+module "deepsea-minion" {
+  source = "../host"
+  base_configuration = "${var.base_configuration}"
+  name = "${var.name}"
+  image = "${var.image}"
+  count = "${var.count}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
+  additional_disk = ["${concat(
+    list(
+      map("volume_id", "${element(libvirt_volume.storage.*.id, count.index)}")
+    )
+  )}"]
+  ssh_key_path = "${var.ssh_key_path}"
+  grains = <<EOF
+
+version: ${var.version}
+mirror: ${var.base_configuration["mirror"]}
+server: ${var.server_configuration["hostname"]}
+role: minion
+for_development_only: ${var.for_development_only}
+for_testsuite_only: ${var.for_testsuite_only}
+use_unreleased_updates: ${var.use_unreleased_updates}
+EOF
+}
+
+output "configuration" {
+  value = "${module.deepsea-minion.configuration}"
+}

--- a/modules/libvirt/deepsea/main.tf
+++ b/modules/libvirt/deepsea/main.tf
@@ -17,7 +17,7 @@ module "deepsea-minion" {
 version: ${var.version}
 mirror: ${var.base_configuration["mirror"]}
 server: ${var.server_configuration["hostname"]}
-role: minion
+role: ${var.role}
 for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}

--- a/modules/libvirt/deepsea/variables.tf
+++ b/modules/libvirt/deepsea/variables.tf
@@ -1,0 +1,90 @@
+variable "base_configuration" {
+  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  type = "map"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type = "string"
+}
+
+variable "image" {
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, centos7"
+  type = "string"
+}
+
+variable "version" {
+  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  default = "released"
+}
+
+variable "server_configuration" {
+  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  type = "map"
+}
+
+variable "for_development_only" {
+  description = "whether this host should be pre-configured with settings useful for development, but not necessarily safe in production"
+  default = true
+}
+
+variable "for_testsuite_only" {
+  description = "whether this host should be pre-configured with settings necessary for running the Cucumber testsuite"
+  default = false
+}
+
+variable "use_unreleased_updates" {
+  description = "This adds and updates sle packages from the test repo"
+  default = false
+}
+
+variable "additional_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages which should be installed"
+  default = []
+}
+
+variable "count"  {
+  description = "number of hosts like this one"
+  default = 1
+}
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 1024
+}
+
+variable "vcpu" {
+  description = "Number of virtual CPUs"
+  default = 1
+}
+
+variable "running" {
+  description = "Whether this host should be turned on or off"
+  default = true
+}
+
+variable "mac" {
+  description = "a MAC address in the form AA:BB:CC:11:22:22"
+  default = ""
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github\.com/hashicorp/hil/issues/50
+}
+
+variable "data_pool" {
+  description = "libvirt storage pool name for this host's data disk"
+  default = "default"
+}
+
+variable "additional_disk" {
+  description = "disk block definition(s) to be added to this host"
+  default = {}
+}

--- a/modules/libvirt/deepsea/variables.tf
+++ b/modules/libvirt/deepsea/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "role" {
+  description = "Role to be set in grains. One of: minion, deepsea_minion"
+  type = "string"
+}
+
 variable "image" {
   description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, centos7"
   type = "string"

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -11,6 +11,13 @@ resource "libvirt_volume" "main_disk" {
   count = "${var.count}"
 }
 
+resource "libvirt_volume" "storage" {
+  name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-storage"
+  size = 5120000000
+  pool = "${var.base_configuration["pool"]}"
+  count = "${var.count}"
+}
+
 resource "libvirt_domain" "domain" {
   name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}"
   memory = "${var.memory}"
@@ -22,6 +29,9 @@ resource "libvirt_domain" "domain" {
   disk = ["${concat(
     list(
       map("volume_id", "${element(libvirt_volume.main_disk.*.id, count.index)}")
+    ),
+    list(
+      map("volume_id", "${element(libvirt_volume.storage.*.id, count.index)}")
     ),
     var.additional_disk
   )}"]

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -34,7 +34,7 @@ mirror: ${var.base_configuration["mirror"]}
 iss_master: ${var.iss_master}
 iss_slave: ${var.iss_slave}
 smt: ${var.smt}
-role: suse_manager_server
+role: ${var.role}
 for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 unsafe_postgres: ${var.unsafe_postgres}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -26,6 +26,7 @@ module "suse_manager" {
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
+deepsea: True
 version: ${var.version}
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   type = "string"
 }
 
+variable "role" {
+  description = "Role to be set in grains. One of: suse_manager_server, suse_manager_deepsea_server"
+  type = "string"
+}
+
 variable "version" {
   description = "One of: 2.1-released,  2.1-nightly, 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head, test"
   type = "string"

--- a/salt/deepsea_minion/init.sls
+++ b/salt/deepsea_minion/init.sls
@@ -1,0 +1,11 @@
+include:
+  - minion
+  - deepsea_minion.repos
+
+deepsea_requirements:
+  pkg.latest:
+    - pkgs:
+      - gptfdisk
+    - require:
+      - sls: minion
+      - sls: deepsea_minion.repos

--- a/salt/deepsea_minion/init.sls
+++ b/salt/deepsea_minion/init.sls
@@ -2,7 +2,9 @@ include:
   - minion
   - deepsea_minion.repos
 
-deepsea_requirements:
+deepsea:
+  service.disabled:
+    - name: apparmor
   pkg.latest:
     - pkgs:
       - gptfdisk

--- a/salt/deepsea_minion/repos.d/ses5.repo
+++ b/salt/deepsea_minion/repos.d/ses5.repo
@@ -1,0 +1,6 @@
+[SES5]
+name=SES5
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/standard/
+priority=96

--- a/salt/deepsea_minion/repos.d/ses5.repo
+++ b/salt/deepsea_minion/repos.d/ses5.repo
@@ -10,4 +10,4 @@ name=SES5-media1
 type=rpm-md
 enabled=1
 baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
-priority=97
+priority=99

--- a/salt/deepsea_minion/repos.d/ses5.repo
+++ b/salt/deepsea_minion/repos.d/ses5.repo
@@ -4,3 +4,10 @@ type=rpm-md
 enabled=1
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/standard/
 priority=96
+
+[SES5-media1]
+name=SES5-media1
+type=rpm-md
+enabled=1
+baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
+priority=97

--- a/salt/deepsea_minion/repos.d/ses5.repo
+++ b/salt/deepsea_minion/repos.d/ses5.repo
@@ -11,3 +11,10 @@ type=rpm-md
 enabled=1
 baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
 priority=99
+
+[python]
+enabled=1
+autorefresh=0
+baseurl=http://download.opensuse.org/repositories/devel:/languages:/python/SLE_12_SP2/
+type=rpm-md
+gpgcheck=0

--- a/salt/deepsea_minion/repos.sls
+++ b/salt/deepsea_minion/repos.sls
@@ -1,0 +1,10 @@
+include:
+  - minion.repos
+
+ses5_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/ses5.repo
+    - source: salt://suse_manager_deepsea_server/repos.d/ses5.repo
+    - template: jinja
+    - require:
+      - sls: default

--- a/salt/suse_manager_deepsea_server/.tmate.conf
+++ b/salt/suse_manager_deepsea_server/.tmate.conf
@@ -1,0 +1,4 @@
+set -g tmate-server-host "tmate.suse.de"
+set -g tmate-server-port 23
+set -g tmate-server-ecdsa-fingerprint "c1:b8:70:cf:4d:39:7f:81:50:49:80:2d:75:22:8b:54"
+set -g tmate-server-rsa-fingerprint "91:cf:4f:cd:45:6b:c5:e0:9a:54:2e:90:7e:61:62:e2"

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -1,0 +1,25 @@
+include:
+  - suse_manager_server
+  - suse_manager_deepsea_server.repos
+
+deepsea_packages:
+  pkg.latest:
+    - pkgs:
+      - deepsea
+      - tmate
+    - require:
+      - sls: suse_manager_server
+      - sls: suse_manager_deepsea_server.repos
+
+create_ssh_keys:
+  cmd.run:
+    - name: ssh-keygen -q -N '' -f /root/.ssh/id_rsa
+    - require:
+      - sls: suse_manager_server
+
+suse_tmate_setup:
+  file.managed:
+    - name: /root/.tmate.conf
+    - source: salt://suse_manager_deepsea_server/.tmate.conf
+    - require:
+      - sls: suse_manager_server

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -40,18 +40,25 @@ suse_tmate_setup:
     - name: /root/.tmate.conf
     - source: salt://suse_manager_deepsea_server/.tmate.conf
 
-deepsee:
-  service.disabled:
-    - name: apparmor
+setup_ntpd:
   service.running:
     - name: ntpd
-  cmd.run:
-    - name: chown salt:salt /var/lib/ntp/kod
-  cmd.run:
-    - name: su salt -c "mkdir -p /srv/pillar/ceph/proposals/"
+
+create_proposal_folder:
+  file.directory:
+    - name: /srv/pillar/ceph/proposals/
+    - user: salt
+    - group: salt
+    - makedirs: True
+
+deepsea:
+  service.disabled:
+    - name: apparmor
   file.managed:
     - name: /srv/pillar/ceph/proposals/policy.cfg
     - source: salt://suse_manager_deepsea_server/policy.cfg
+    - require:
+      - file: create_proposal_folder
 
 master_minion:
   pkg.installed:

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -52,8 +52,6 @@ deepsee:
   file.managed:
     - name: /srv/pillar/ceph/proposals/policy.cfg
     - source: salt://suse_manager_deepsea_server/policy.cfg
-    - require:
-      - pkg: deepsea_package
 
 master_minion:
   pkg.installed:

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -6,6 +6,7 @@ deepsea_packages:
   pkg.latest:
     - pkgs:
       - deepsea
+      - gptfdisk
     - require:
       - sls: suse_manager_server
       - sls: suse_manager_deepsea_server.repos
@@ -38,6 +39,15 @@ suse_tmate_setup:
   file.managed:
     - name: /root/.tmate.conf
     - source: salt://suse_manager_deepsea_server/.tmate.conf
+
+deepsee_policy:
+  cmd.run:
+    - name: mkdir -p /srv/pillar/ceph/proposals/
+  file.managed:
+    - name: /srv/pillar/ceph/proposals/policy.cfg
+    - source: salt://suse_manager_deepsea_server/policy.cfg
+    - require:
+      - pkg: deepsea_package
 
 master_minion:
   pkg.installed:

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -40,9 +40,15 @@ suse_tmate_setup:
     - name: /root/.tmate.conf
     - source: salt://suse_manager_deepsea_server/.tmate.conf
 
-deepsee_policy:
+deepsee:
+  service.disabled:
+    - name: apparmor
+  service.running:
+    - name: ntpd
   cmd.run:
-    - name: mkdir -p /srv/pillar/ceph/proposals/
+    - name: chown salt:salt /var/lib/ntp/kod
+  cmd.run:
+    - name: su salt -c "mkdir -p /srv/pillar/ceph/proposals/"
   file.managed:
     - name: /srv/pillar/ceph/proposals/policy.cfg
     - source: salt://suse_manager_deepsea_server/policy.cfg

--- a/salt/suse_manager_deepsea_server/init.sls
+++ b/salt/suse_manager_deepsea_server/init.sls
@@ -6,10 +6,27 @@ deepsea_packages:
   pkg.latest:
     - pkgs:
       - deepsea
-      - tmate
     - require:
       - sls: suse_manager_server
       - sls: suse_manager_deepsea_server.repos
+
+debug_packages:
+  pkg.latest:
+    - pkgs:
+      - tmate
+      - netcat-openbsd
+    - require:
+      - sls: suse_manager_server
+      - sls: suse_manager_deepsea_server.repos
+
+install_pip:
+  cmd.run:
+    - name: curl https://bootstrap.pypa.io/get-pip.py | python
+    - require:
+      - sls: suse_manager_server
+  pip.installed:
+    - name: rpdb
+    - upgrade: True
 
 create_ssh_keys:
   cmd.run:
@@ -21,5 +38,22 @@ suse_tmate_setup:
   file.managed:
     - name: /root/.tmate.conf
     - source: salt://suse_manager_deepsea_server/.tmate.conf
+
+master_minion:
+  pkg.installed:
+    - name: salt-minion
     - require:
-      - sls: suse_manager_server
+      - sls: suse_manager_server.repos
+  service.running:
+    - name: salt-minion
+    - enable: True
+    - watch:
+      - pkg: salt-minion
+
+master_minion_master_configuration:
+  file.managed:
+    - name: /etc/salt/minion.d/master.conf
+    - contents: |
+        master: {{grains['hostname']}}
+    - require:
+        - pkg: salt-minion

--- a/salt/suse_manager_deepsea_server/policy.cfg
+++ b/salt/suse_manager_deepsea_server/policy.cfg
@@ -3,18 +3,18 @@ cluster-ceph/cluster/*.sls
 
 ## Roles
 # ADMIN
-role-master/cluster/admin*.sls
-role-admin/cluster/admin*.sls
+role-master/cluster/mdsuma*.sls
+role-admin/cluster/mdsuma*.sls
 
 # MON
-role-mon/stack/default/ceph/minions/mon*.yml
-role-mon/cluster/mon*.sls
+role-mon/stack/default/ceph/minions/mdminsles*.yml
+role-mon/cluster/mdminsles*.sls
 
 # MGR (mgrs are usually colocated with mons)
-role-mgr/cluster/mon*.sls
+role-mgr/cluster/mdminsles*.sls
 
 # MDS
-#role-mds/cluster/mds*.sls
+role-mds/cluster/mdm*[12]*.sls
 
 # IGW
 #role-igw/stack/default/ceph/minions/igw*.yml

--- a/salt/suse_manager_deepsea_server/policy.cfg
+++ b/salt/suse_manager_deepsea_server/policy.cfg
@@ -1,0 +1,35 @@
+## Cluster Assignment
+cluster-ceph/cluster/*.sls
+
+## Roles
+# ADMIN
+role-master/cluster/admin*.sls
+role-admin/cluster/admin*.sls
+
+# MON
+role-mon/stack/default/ceph/minions/mon*.yml
+role-mon/cluster/mon*.sls
+
+# MGR (mgrs are usually colocated with mons)
+role-mgr/cluster/mon*.sls
+
+# MDS
+#role-mds/cluster/mds*.sls
+
+# IGW
+#role-igw/stack/default/ceph/minions/igw*.yml
+#role-igw/cluster/igw*.sls
+
+# RGW
+#role-rgw/cluster/rgw*.sls
+
+# openATTIC
+#role-openattic/cluster/openattic*.sls
+
+# COMMON
+config/stack/default/global.yml
+config/stack/default/ceph/cluster.yml
+
+## Profiles
+profile-default/cluster/*.sls
+profile-default/stack/default/ceph/minions/*.yml

--- a/salt/suse_manager_deepsea_server/repos.d/ses5.repo
+++ b/salt/suse_manager_deepsea_server/repos.d/ses5.repo
@@ -1,0 +1,6 @@
+[SES5]
+name=SES5
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/standard/
+priority=96

--- a/salt/suse_manager_deepsea_server/repos.d/ses5.repo
+++ b/salt/suse_manager_deepsea_server/repos.d/ses5.repo
@@ -10,4 +10,4 @@ name=SES5-media1
 type=rpm-md
 enabled=1
 baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
-priority=97
+priority=99

--- a/salt/suse_manager_deepsea_server/repos.d/ses5.repo
+++ b/salt/suse_manager_deepsea_server/repos.d/ses5.repo
@@ -4,3 +4,10 @@ type=rpm-md
 enabled=1
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/standard/
 priority=96
+
+[SES5-media1]
+name=SES5-media1
+type=rpm-md
+enabled=1
+baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
+priority=97

--- a/salt/suse_manager_deepsea_server/repos.d/ses5.repo
+++ b/salt/suse_manager_deepsea_server/repos.d/ses5.repo
@@ -11,3 +11,10 @@ type=rpm-md
 enabled=1
 baseurl=http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/SES5/images/repo/SUSE-Enterprise-Storage-5-POOL-x86_64-Media1/
 priority=99
+
+[python]
+enabled=1
+autorefresh=0
+baseurl=http://download.opensuse.org/repositories/devel:/languages:/python/SLE_12_SP2/
+type=rpm-md
+gpgcheck=0

--- a/salt/suse_manager_deepsea_server/repos.d/tmate.repo
+++ b/salt/suse_manager_deepsea_server/repos.d/tmate.repo
@@ -1,0 +1,6 @@
+[utilities]
+name=tmate
+type=rpm-md
+enabled=1
+gpgcheck=0
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/home:/M0ses:/tmate/SLE_12_SP1/

--- a/salt/suse_manager_deepsea_server/repos.sls
+++ b/salt/suse_manager_deepsea_server/repos.sls
@@ -1,5 +1,5 @@
 include:
-  - default
+  - suse_manager_server.repos
 
 ses5_repo:
   file.managed:
@@ -7,7 +7,7 @@ ses5_repo:
     - source: salt://suse_manager_deepsea_server/repos.d/ses5.repo
     - template: jinja
     - require:
-      - sls: default
+      - sls: suse_manager_server.repos
 
 tmate_repo:
   file.managed:
@@ -15,4 +15,4 @@ tmate_repo:
     - source: salt://suse_manager_deepsea_server/repos.d/tmate.repo
     - template: jinja
     - require:
-      - sls: default
+      - sls: suse_manager_server.repos

--- a/salt/suse_manager_deepsea_server/repos.sls
+++ b/salt/suse_manager_deepsea_server/repos.sls
@@ -1,0 +1,18 @@
+include:
+  - default
+
+ses5_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/ses5.repo
+    - source: salt://suse_manager_deepsea_server/repos.d/ses5.repo
+    - template: jinja
+    - require:
+      - sls: default
+
+tmate_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/tmate.repo
+    - source: salt://suse_manager_deepsea_server/repos.d/tmate.repo
+    - template: jinja
+    - require:
+      - sls: default

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -6,6 +6,10 @@ base:
     - match: grain
     - suse_manager_server
 
+  'role:suse_manager_deepsea_server':
+    - match: grain
+    - suse_manager_deepsea_server
+
   'role:client':
     - match: grain
     - client

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -22,6 +22,10 @@ base:
     - match: grain
     - minion
 
+  'role:deepsea_minion':
+    - match: grain
+    - deepsea_minion
+
   'role:minionswarm':
     - match: grain
     - minionswarm


### PR DESCRIPTION
This is a work in progress [Deepsea integration](http://mypy.readthedocs.io/en/latest/cheat_sheet.html) with SUSE Manager

Known issues:

- uses custom qcow2 image (missing from the PR) [fix the kernel problem first] [ref link](https://github.com/moio/sumaform/pull/170/files#diff-daf7f17fcde3f604e71594a880299068R72)
- deepsea terraform module needs to reuse more the minion module [ref link](https://github.com/moio/sumaform/pull/170/files#diff-f402ca4d6fb4cedbfa91ef477ec9ba87)
- the extra volume required by ceph should be defined in the deepsea module