### PR TITLE
Testsuite: do not install unneeded packages

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -3,12 +3,6 @@
 include:
   - client.repos
 
-# this can fail on sles11sp4 and break other pkg install.
-# better alone. 
-openscap-extra-probes_client:
-  pkg.installed:
-    - name: openscap-extra-probes
-
 cucumber_requisites:
   pkg.installed:
     - pkgs:
@@ -26,7 +20,7 @@ cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
-      {% if '122' in grains['osrelease'] %}
+      {% if '12' in grains['osrelease'] %}
       - aaa_base-extras
       {% endif %}
       {% endif %}

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -21,7 +21,9 @@ cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
+      {% if '11' in grains['osrelease'] %}
       - aaa_base-extras
+      {% endif %}
       {% endif %}
     - require:
       - sls: client.repos

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -26,7 +26,7 @@ cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
-      {% if '11' in grains['osrelease'] %}
+      {% if '122' in grains['osrelease'] %}
       - aaa_base-extras
       {% endif %}
       {% endif %}

--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -3,6 +3,12 @@
 include:
   - client.repos
 
+# this can fail on sles11sp4 and break other pkg install.
+# better alone. 
+openscap-extra-probes_client:
+  pkg.installed:
+    - name: openscap-extra-probes
+
 cucumber_requisites:
   pkg.installed:
     - pkgs:
@@ -11,7 +17,6 @@ cucumber_requisites:
       - spacewalk-check
       - spacewalk-oscap
       - rhncfg-actions
-      - openscap-extra-probes
       - openscap-utils
       - man
       - wget

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -3,11 +3,15 @@
 include:
   - minion.repos
 
+# this can break other imp. pkg. alone is better
+openscap-extra-probes_minion:
+  pkg.installed:
+    - name: openscap-extra-probes
+
 cucumber_requisites:
   pkg.installed:
     - pkgs:
       - salt-minion
-      - openscap-extra-probes
       - openscap-utils
       {% if grains['os'] == 'SUSE' %}
       - openscap-content

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -18,7 +18,7 @@ cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
-      {% if '11' in grains['osrelease'] %}
+      {% if '12' in grains['osrelease'] %}
       - aaa_base-extras
       {% endif %}
       {% endif %}

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -14,7 +14,9 @@ cucumber_requisites:
       - andromeda-dummy
       - milkyway-dummy
       - virgo-dummy
+      {% if '11' in grains['osrelease'] %}
       - aaa_base-extras
+      {% endif %}
       {% endif %}
     - require:
       - sls: minion.repos

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -3,11 +3,6 @@
 include:
   - minion.repos
 
-# this can break other imp. pkg. alone is better
-openscap-extra-probes_minion:
-  pkg.installed:
-    - name: openscap-extra-probes
-
 cucumber_requisites:
   pkg.installed:
     - pkgs:


### PR DESCRIPTION
Fix this:
An error was encountered while installing package(s): Zypper command
failure: Package 'aaa_base-extras' not found.