### PR TITLE
Make SLE12SP3 image available on sumaform

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -78,6 +78,19 @@ module "suma3pg" {
 }
 ```
 
+Additionally, a SLES 12 SP3 image is already available on sumaform but it's not the default selection for any deployment. You can explicitely set the image on your `main.tf` system definition:
+
+```hcl
+module "minsles12sp3" {
+  source = "./modules/libvirt/minion"
+  base_configuration = "${module.base.configuration}"
+
+  name = "minsles12sp3"
+  image = "sles12sp3"
+  server_configuration = "${module.suma3pg.configuration}"
+}
+```
+
 ## Proxies
 
 A `proxy` module is similar to a `client` module but has a `version` and a `server` variable pointing to the upstream server. You can then point clients to the proxy, as in the example below:

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -63,7 +63,8 @@ module "minionsles12sp1" {
 This will create 10 minions connected to the `suma3pg` server.
 
 ## Change the base OS for supported SUSE Manager versions
-You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1` and `sles12sp2`.
+
+You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1`, `sles12sp2` and `sles12sp3`.
 
 The following example creates a SUSE Manager server using "nightly" packages from version 3 based on SLES 12 SP2:
 
@@ -75,19 +76,6 @@ module "suma3pg" {
   image = "sles12sp2"
   name = "suma3pg"
   version = "3.0-nightly"
-}
-```
-
-Additionally, a SLES 12 SP3 image is already available on sumaform but it's not the default selection for any deployment. You can explicitely set the image on your `main.tf` system definition:
-
-```hcl
-module "minsles12sp3" {
-  source = "./modules/libvirt/minion"
-  base_configuration = "${module.base.configuration}"
-
-  name = "minsles12sp3"
-  image = "sles12sp3"
-  server_configuration = "${module.suma3pg.configuration}"
 }
 ```
 

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -12,7 +12,7 @@ module "base" {
   // bridge = ""
   // name_prefix = ""
   // you need always sles12sp1 because controller is based on that.
-  images = ["centos7", "sles12sp1", "sles12sp2"]
+  images = ["centos7", "sles12sp1", "sles12sp2", "sles12sp3"]
 }
 
 module "head-srv" {

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -55,7 +55,7 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default = ["centos7",  "opensuse422",  "sles11sp3",  "sles11sp4",  "sles12",   "sles12sp1",  "sles12sp2"]
+  default = ["centos7",  "opensuse422",  "sles11sp3",  "sles11sp4",  "sles12",   "sles12sp1",  "sles12sp2", "sles12sp3"]
   type = "list"
 }
 
@@ -69,6 +69,7 @@ variable "image_locations" {
     sles12 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12.x86_64.qcow2"
     sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
     sles12sp2 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
+    sles12sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2"
   }
   type = "map"
 }

--- a/salt/default/repos.d/SLE-12-SP3-x86_64-Pool.repo
+++ b/salt/default/repos.d/SLE-12-SP3-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-12-SP3-x86_64-Pool]
+name=SLE-12-SP3-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/

--- a/salt/default/repos.d/SLE-12-SP3-x86_64-Test-Update.repo
+++ b/salt/default/repos.d/SLE-12-SP3-x86_64-Test-Update.repo
@@ -1,0 +1,7 @@
+[SLE-12-SP3-x86_64-Test-Update]
+name=SLE-12-SP3-x86_64-Test-Update
+type=rpm-md
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/
+gpgcheck=1
+gpgkey=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/repodata/repomd.xml.key
+enabled=1

--- a/salt/default/repos.d/SLE-12-SP3-x86_64-Update.repo
+++ b/salt/default/repos.d/SLE-12-SP3-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-12-SP3-x86_64-Update]
+name=SLE-12-SP3-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -201,6 +201,28 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
+{% elif grains['osrelease'] == '12.3' %}
+
+os_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-12-SP3-x86_64-Pool.repo
+    - source: salt://default/repos.d/SLE-12-SP3-x86_64-Pool.repo
+    - template: jinja
+
+os_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-12-SP3-x86_64-Update.repo
+    - source: salt://default/repos.d/SLE-12-SP3-x86_64-Update.repo
+    - template: jinja
+
+{% if grains.get('use_unreleased_updates', False) %}
+test_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SLE-12-SP3-x86_64-Test-Update.repo
+    - source: salt://default/repos.d/SLE-12-SP3-x86_64-Test-Update.repo
+    - template: jinja
+{% endif %}
+
 {% endif %}
 
 tools_pool_repo:

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -39,6 +39,10 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc
 mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP2/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP2/x86_64/product/
 mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update/
 
+# SLES 12 SP3
+mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/
+
 # SUSE Manager 3.0
 mirror --continue --delete --loop --parallel=3 --verbose=3 mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product/ mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Server/3.0/x86_64/product/
 mirror --continue --delete --loop --parallel=3 --verbose=3 -x "src/.*" -x "nosrc/.*" -x ".*\.drpm" mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.0/x86_64/update/ mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Server/3.0/x86_64/update/
@@ -86,6 +90,9 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 
 # SLES 12 SP2 Test
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP2:/x86_64/update/ ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP2:/x86_64/update/
+
+# SLES 12 SP3 Test
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/ ibs/SUSE:/Maintenance:/Test:/SLE-SERVER:/12-SP3:/x86_64/update/
 
 # SUSE Manager Head
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.rpm" -i "noarch/.*\.rpm" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/ ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/


### PR DESCRIPTION
This PR makes the SLE12SP3 image available on sumaform in order to be able to deploy and test SUSE Manager on SP3 systems. Also adds SLE12SP3 repositories to be synced by the package mirror.

The SLE12SP3 qcow2 image is already built on: https://build.suse.de/package/show/Devel:Galaxy:Terraform:Images/sles12sp3

This PR addresses https://github.com/SUSE/spacewalk/issues/1958