### PR TITLE
Bugfix: Reset 'machine-id' properly to prevent duplicates

### DIFF
--- a/salt/default/ids.sls
+++ b/salt/default/ids.sls
@@ -1,12 +1,12 @@
 systemd_machine_id:
   cmd.run:
-    - name: rm /etc/machine-id && systemd-machine-id-setup && touch /etc/machine-id-already-setup
+    - name: rm /etc/machine-id && rm /var/lib/dbus/machine-id && dbus-uuidgen --ensure && systemd-machine-id-setup && touch /etc/machine-id-already-setup
     - creates: /etc/machine-id-already-setup
     - onlyif: test -f /usr/bin/systemd-machine-id-setup
 
 dbus_machine_id:
   cmd.run:
-    - name: dbus-uuidgen --ensure
+    - name: rm /var/lib/dbus/machine-id && dbus-uuidgen --ensure
     - creates: /var/lib/dbus/machine-id
     - unless: test -f /usr/bin/systemd-machine-id-setup
 


### PR DESCRIPTION
This PR fixes a problem while resetting the 'machine-id' for the deployed machines. Currently, the machine id are not being reset properly so I ended up with duplicates machine-id for different systems running the same image after deployment.

According with the documentation at https://wiki.microfocus.com/index.php?title=SUSE_Manager/Register_Clones#Steps_for_registering_a_cloned_system_to_SUSE_Manager , the right way to reset the machine id is:

> 
> 5.1. On the SLES 11 and RH5/6 clients exhibiting the issue enter the following as root:
> 
>  rm /var/lib/dbus/machine-id
>  dbus-uuidgen --ensure
> 
> 5.2. On SLES 12, or RH7-based clients exhibiting the issue enter the following as root:
> 
>  rm /etc/machine-id
>  rm /var/lib/dbus/machine-id
>  dbus-uuidgen --ensure
>  systemd-machine-id-setup
> 

Before this PR, on systemd machines, the `systemd_machine_id` state is only removing the `/etc/machine-id` file and then executing `systemd-machine-id-setup`. This is problematic because if there is a previously existing `/var/lib/dbus/machine-id` file at the time of executing `systemd-machine-id-setup` call, then the old machine id from `/var/lib/dbus/machine-id` will be reused for the new `/etc/machine-id`, and we will end up having the same machine id after resetting.

This PR does explicitly what documentation said about resetting the machine-id, so deployed machines using the same image won't end up having the same machine id.

Notice that our `systemd_machine_id` and `dbus_machine_id` cannot apply for the same system because the `onlyif / unless` parameters.

What do you think about this? 😄 