### PR TITLE
Automatically accept minion keys by default

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -23,6 +23,7 @@ module "head-srv" {
   version = "head"
   for_development_only = false
   for_testsuite_only = true
+  auto_accept = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -55,6 +55,7 @@ iss_master: ${var.iss_master}
 iss_slave: ${var.iss_slave}
 for_development_only: True
 for_testsuite_only: False
+auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 timezone: ${var.timezone}
 authorized_keys: null

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -98,6 +98,11 @@ variable "iss_slave" {
   default = "null"
 }
 
+variable "auto_accept" {
+  description = "whether to automatically accept all incoming minion keys"
+  default = true
+}
+
 variable "monitored" {
   description = "whether this host should be monitored via Prometheus"
   default = false

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -40,6 +40,7 @@ for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 unsafe_postgres: ${var.unsafe_postgres}
 use_unreleased_updates: ${var.use_unreleased_updates}
+auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 log_server: ${var.log_server}
 from_email: ${var.from_email}

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -63,6 +63,11 @@ variable "smt" {
   default = "null"
 }
 
+variable "auto_accept" {
+  description = "whether to automatically accept all incoming minion keys"
+  default = true
+}
+
 variable "monitored" {
   description = "whether this host should be monitored via Prometheus"
   default = false

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -10,6 +10,7 @@ include:
   - suse_manager_server.testsuite
   - suse_manager_server.prometheus
   - suse_manager_server.filebeat
+  - suse_manager_server.salt_master
 
 {% if '2.1' in grains['version'] %}
 # remove SLES product release package, it's replaced by SUSE Manager's

--- a/salt/suse_manager_server/salt_master.sls
+++ b/salt/suse_manager_server/salt_master.sls
@@ -1,0 +1,16 @@
+{% if '2.1' not in grains['version'] and grains.get('auto_accept') %}
+custom_salt_master_configuration:
+  file.managed:
+    - name: /etc/salt/master.d/custom.conf
+    - contents: |
+        auto_accept: True
+    - require:
+        - pkg: suse_manager_packages
+
+salt_master:
+  service.running:
+    - name: salt-master
+    - enable: True
+    - watch:
+      - file: custom_salt_master_configuration
+{% endif %}


### PR DESCRIPTION
Enables `auto_accept` on all Salt masters by default.