### PR TITLE
Add option to specify an Activation Key for minions

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -86,6 +86,20 @@ module "suma3pg" {
 }
 ```
 
+## Activation Keys for minions
+
+You can specify an Activation Key string for minions to use at onboarding time to a SUSE Manager Server. An example follows:
+
+module "min" {
+  source = "./modules/libvirt/minion"
+  base_configuration = "${module.base.configuration}"
+
+  name = "min"
+  image = "sles12sp2"
+  server_configuration = "${module.suma3pg.configuration}"
+  activation_key = "1-DEFAULT"
+}
+
 ## Change the base OS for supported SUSE Manager versions
 
 You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1`, `sles12sp2` and `sles12sp3`.

--- a/modules/aws/host/main.tf
+++ b/modules/aws/host/main.tf
@@ -65,6 +65,9 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
 
+susemanager:
+  activation_key: ${var.activation_key}
+
 EOF
 
     destination = "/etc/salt/grains"

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -88,6 +88,11 @@ variable "cc_password" {
   default = "null"
 }
 
+variable "activation_key" {
+  description = "an Activation Key to be used when onboarding a minion"
+  default = "null"
+}
+
 variable "server" {
   description = "Main server for this host"
   default = "null"

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -21,6 +21,10 @@ role: minion
 for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
+
+susemanager:
+  activation_key: ${var.activation_key}
+
 EOF
 }
 

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -23,6 +23,11 @@ variable "server_configuration" {
   type = "map"
 }
 
+variable "activation_key" {
+  description = "an Activation Key to be used when onboarding this minion"
+  default = "null"
+}
+
 variable "for_development_only" {
   description = "whether this host should be pre-configured with settings useful for development, but not necessarily safe in production"
   default = true


### PR DESCRIPTION
This is another requirement for automated (performance) tests, as we want to onboard minions directly with the correct channel set, but useful in general.