### PR TITLE
Add screen package to the controller machine

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -92,3 +92,10 @@ testsuite_env_vars:
     - user: root
     - group: root
     - mode: 755
+
+extra_pkgs:
+  pkg.installed:
+    - pkgs:
+      - tmux
+    - require:
+      - sls: controller.repos


### PR DESCRIPTION
Anytime I setup a new controller, I find myself in need of `screen` tool to run the test suite with, so I can log out of the machine re-attach the terminal which the tests are running at a later time.

I'd be nice to have this tool available by default on the controller machine.