### PR TITLE
[WIP] use new updated ruby repo for the testsuite

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -55,7 +55,7 @@ cucumber_requisites:
       - rubygem-websocket-driver
       - ruby2.1-rubygem-jwt
       - rubygem-mime-types
-      - ruby2.1-rubygem-builder
+      - rubygem-builder
       - rubygem-cliver
       - ruby2.1-rubygem-rake
       - rubygem-twopence

--- a/salt/controller/repos.d/Devel_Galaxy_ruby.repo
+++ b/salt/controller/repos.d/Devel_Galaxy_ruby.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_ruby]
+name=ruby packages (SLE_12)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/ruby/SLE_12/

--- a/salt/controller/repos.d/Devel_Galaxy_ruby_test.repo
+++ b/salt/controller/repos.d/Devel_Galaxy_ruby_test.repo
@@ -1,5 +1,0 @@
-[Devel_Galaxy_ruby_test]
-name=Test new ruby packages (SLE_12)
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/ruby:/test/SLE_12/

--- a/salt/controller/repos.sls
+++ b/salt/controller/repos.sls
@@ -1,10 +1,10 @@
 include:
   - default
 
-ruby_test_repo:
+ruby_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_ruby_test.repo
-    - source: salt://controller/repos.d/Devel_Galaxy_ruby_test.repo
+    - name: /etc/zypp/repos.d/Devel_Galaxy_ruby.repo
+    - source: salt://controller/repos.d/Devel_Galaxy_ruby.repo
     - template: jinja
     - require:
       - sls: default
@@ -21,5 +21,5 @@ refresh_controller_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
     - require:
-      - file: ruby_test_repo
+      - file: ruby_repo
       - file: sle_12_sp1_sdk_pool

--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -136,7 +136,7 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*"  -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Oracle:/SLE11/SLE_11_SP3/ ibs/Devel:/Galaxy:/Oracle:/SLE11/SLE_11_SP3/
 
 # Testsuite tools repo
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*"  -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/ruby:/test/SLE_12/ ibs/Devel:/Galaxy:/ruby:/test/SLE_12/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*"  -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/ruby/SLE_12/ ibs/Devel:/Galaxy:/ruby/SLE_12/
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*"  -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1/ ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1/
 
 open http://download.opensuse.org


### PR DESCRIPTION
Cleanup of an unused repo and put the currently used rpms inside: https://github.com/SUSE/spacewalk/issues/1549

Started to update some packages to new versions: https://github.com/SUSE/spacewalk/issues/1548

Running job to see what breaks: https://ci.nue.suse.com/view/Manager/view/Manager-Head/job/manager-Head-sumaform-cucumber/1902/