### PR TITLE
Head should use packages build for SP3

### DIFF
--- a/salt/mirror/mirror.lftp
+++ b/salt/mirror/mirror.lftp
@@ -125,7 +125,7 @@ mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/ ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/
 
 # SUSE Manager Head devel
-mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.develHead\.x86_64\.rpm" -i "noarch/.*\.develHead\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/ ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/
+mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*\.develHead\.x86_64\.rpm" -i "noarch/.*\.develHead\.noarch\.rpm" -x ".*-kit-.*" -x ".*\.mirrorlist" -x ".*\.drpm" /ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3/ ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3/
 
 # SLE 11 (SP3 and SP4) Manager Tools Head devel
 mirror --continue --delete --loop --parallel=3 --verbose=3 -i "repodata/.*" -i "x86_64/.*" -i "noarch/.*" -x ".*\.mirrorlist" /ibs/Devel:/Galaxy:/Manager:/Head:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/ ibs/Devel:/Galaxy:/Manager:/Head:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse/

--- a/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_Head.repo
+++ b/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_Head.repo
@@ -1,6 +1,6 @@
 [Devel_Galaxy_Manager_Head]
-name=Devel Project for SUSE Manager Head (SLE_12_SP2)
+name=Devel Project for SUSE Manager Head (SLE_12_SP3)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3/
 priority=96

--- a/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head.repo
+++ b/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head.repo
@@ -1,6 +1,6 @@
 [Devel_Galaxy_Manager_Head]
-name=Devel Project for SUSE Manager Head (SLE_12_SP2)
+name=Devel Project for SUSE Manager Head (SLE_12_SP3)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP2/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3/
 priority=96


### PR DESCRIPTION
Head does not build anymore for SP2. We need to use SP3 now.