### PR TITLE
Install and run bootstrap script only in dev mode

### DIFF
--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -70,6 +70,8 @@ wget:
     - require:
       - sls: suse_manager_proxy.repos
 
+{% if grains['for_development_only'] %}
+
 base_bootstrap_script:
   file.managed:
     - name: /root/bootstrap.sh
@@ -197,3 +199,5 @@ ca-configuration-checksum:
     - creates: /srv/www/htdocs/pub/rhn-ca-openssl.cnf.sha512
     - require:
       - file: ca-configuration
+
+{% endif %}


### PR DESCRIPTION
This PR fixes the incompatibilities between testsuite and proxy (issues #122 and #204).

It does it by installing and running the bootstrap script in
 `salt/suse_manager_proxy/init.sls` 
only when
 `for_development_only` 
is true, just like it is already done in
 `sumaform/salt/suse_manager_server/initial_content.sls` 
.

Same goes for CAs etc.
