### PR TITLE
set timezone after the timezone package is installed

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -44,6 +44,8 @@ timezone_setting:
   timezone.system:
     - name: {{ grains['timezone'] }}
     - utc: True
+    - require:
+      - file: timezone_symlink
 
 {% if grains.get('use_unreleased_updates') | default(False, true) %}
 update_sles_test:

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -24,11 +24,6 @@ minimal_package_update:
     - require:
       - sls: default.repos
 
-timezone_setting:
-  timezone.system:
-    - name: {{ grains['timezone'] }}
-    - utc: True
-
 timezone_package:
   pkg.installed:
 {% if grains['os_family'] == 'Suse' %}
@@ -44,6 +39,11 @@ timezone_symlink:
     - force: true
     - require:
       - pkg: timezone_package
+
+timezone_setting:
+  timezone.system:
+    - name: {{ grains['timezone'] }}
+    - utc: True
 
 {% if grains.get('use_unreleased_updates') | default(False, true) %}
 update_sles_test:


### PR DESCRIPTION
state "timezone_setting" is failing because there is no localtime symlink. Try to call this state after the timezone package is installed

```
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec): ----------
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):           ID: timezone_setting
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):     Function: timezone.system
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):         Name: Europe/Berlin
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):       Result: False
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):      Comment: Unable to compare desired timezone 'Europe/Berlin' to system timezone: Failed to read /etc/localtime to determine current timezone: No such file or directory
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):      Started: 06:56:43.109552
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):     Duration: 0.77 ms
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec):      Changes:   
module.min-sles12sp3.minion.libvirt_domain.domain (remote-exec): ----------
```