### PR TITLE
Make the PROXY environment variable optional

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -1,9 +1,11 @@
-export TESTHOST={{ grains.get("server") }}
-export PROXY={{ grains.get("proxy") }}
-export CLIENT={{ grains.get("client") }}
-export MINION={{ grains.get("minion") }}
-export SSHMINION={{ grains.get("ssh_minion") }}
-export CENTOSMINION={{ grains.get("centos_minion") }}
+export TESTHOST={{ grains.get('server') }}
+{% if grains.has_key('proxy') %}
+export PROXY={{ grains.get('proxy') }}
+{% endif %}
+export CLIENT={{ grains.get('client') }}
+export MINION={{ grains.get('minion') }}
+export SSHMINION={{ grains.get('ssh_minion') }}
+export CENTOSMINION={{ grains.get('centos_minion') }}
 
 # phantomjs needs certificate of suma server to run secure websockets
 if [ ! -f /etc/pki/trust/anchors/$TESTHOST.cert ]; then


### PR DESCRIPTION
Do not generate "export PROXY=..." when the proxy grain does not exist.

Makes the value "None" generated by {{ grains.get('proxy') }} disappear.

We might want to do the same for the SSH minion and the CentOS minion in the future.