### PR TITLE
change hostname using state

### DIFF
--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -1,9 +1,15 @@
-hosts_file:
-  file.append:
-    - name: /etc/hosts
-    - text: |
-        127.0.1.1 {{ grains['hostname'] }}.{{ grains['domain'] }} {{ grains['hostname'] }}
-        ::1 {{ grains['hostname'] }}.{{ grains['domain'] }} {{ grains['hostname'] }}
+hosts_file_ipv4:
+  host.present:
+    - ip: 127.0.1.1
+    - names:
+      - {{ grains['hostname'] }}.{{ grains['domain'] }}
+      - {{ grains['hostname'] }}
+
+hosts_file_ipv6:
+  host.present:
+    - ip: ::1
+    - names:
+      - {{ grains['hostname'] }}.{{ grains['domain'] }}
 
 temporary_hostname:
   cmd.run:

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -1,7 +1,7 @@
 hosts_file_ipv4:
-  host.present:
-    - ip: 127.0.1.1
-    - names:
+  host.only:
+    - name: 127.0.1.1
+    - hostnames:
       - {{ grains['hostname'] }}.{{ grains['domain'] }}
       - {{ grains['hostname'] }}
 


### PR DESCRIPTION
Appending ::1 line to /etc/hosts cause duplicate entry.

just appending the hostnames to ::1 has bad side effects.
At least not setting the short hostname to ::1 prevent returning "localhost" with hostname --fqdn

Without this I had the following effect:

```
$> hostname
suma-31-cli-sles12sp3
$> hostname -f 
suma-31-cli-sles12sp3.mgr.suse.de
$> python -c "import socket; print socket.getfqdn()"
localhost
```

No duplicate ::1 but adding FQDN and short hostname to the existing ::1 entry cause this:
```
$> hostname
suma-31-cli-sles12sp3
$> hostname -f 
localhost
$> python -c "import socket; print socket.getfqdn()"
localhost
```
Do not add the short hostname to the existing ::1 entry print the right things:
```
$> hostname
suma-31-cli-sles12sp3
$> hostname -f 
suma-31-cli-sles12sp3.mgr.suse.de
$> python -c "import socket; print socket.getfqdn()"
suma-31-cli-sles12sp3.mgr.suse.de
```
