### PR TITLE
Fixing FQDN problems

### DIFF
--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -16,7 +16,7 @@ temporary_hostname:
 permanent_hostname:
   file.managed:
     - name: /etc/hostname
-    - contents: {{ grains['hostname'] }}
+    - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
 
 permanent_hostname_backward_compatibility_link:
   file.symlink:


### PR DESCRIPTION
We need the domain name inside ```/etc/hostname```, this PR adds it