### PR TITLE
More hostname fixes

### DIFF
--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -23,13 +23,12 @@ permanent_hostname:
     - name: /etc/hostname
     - contents: {{ grains['hostname'] }}
 
-{% if grains['os_family'] == 'Suse' %}
-SUSE_specific_permanent_hostname:
+# /etc/HOSTNAME is supposed to always contain the FQDN
+legacy_permanent_hostname:
   file.managed:
     - name: /etc/HOSTNAME
     - follow_symlinks: False
     - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
-{% endif %}
 
 # set the hostname and FQDN name in /etc/hosts
 # this is not needed if a proper DNS server is in place, but when using avahi this

--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -1,4 +1,43 @@
-hostname:
+# set the hostname in the kernel, this is needed for Red Hat systems
+# and does not hurt in others
+kernel_hostname:
+  cmd.run:
+    - name: sysctl kernel.hostname={{ grains['hostname'] }}
+    - unless: sysctl --values kernel.hostname | grep -w {{ grains['hostname'] }}
+
+# set the hostname in userland. There is no consensus among distros
+# but Debian prefers the short name, SUSE demands the short name,
+# Red Hat suggests the FQDN but works with the short name.
+# Bottom line: short name is used here
+temporary_hostname:
+  cmd.run:
+    {% if grains['init'] == 'systemd' %}
+    - name: hostnamectl set-hostname {{ grains['hostname'] }}
+    {% else %}
+    - name: hostname {{ grains['hostname'] }}
+    {% endif %}
+
+# set the hostname in the filesystem, matching the temporary hostname
+permanent_hostname:
+  file.managed:
+    - name: /etc/hostname
+    - contents: {{ grains['hostname'] }}
+
+{% if grains['os_family'] == 'Suse' %}
+SUSE_specific_permanent_hostname:
+  file.managed:
+    - name: /etc/HOSTNAME
+    - follow_symlinks: False
+    - contents: {{ grains['hostname'] }}.{{ grains['domain'] }}
+{% endif %}
+
+# set the hostname and FQDN name in /etc/hosts
+# this is not needed if a proper DNS server is in place, but when using avahi this
+# might not be the case. The script tries to to use real IP addresses in order not
+# to break round-robin DNS resolution and only uses 127.0.1.1 as a last resort.
+{% if grains['use_avahi'] %}
+hosts_file_hack:
   cmd.script:
-    - name: salt://default/set_hostname.py
+    - name: salt://default/set_ip_in_etc_hosts.py
     - args: "{{ grains['hostname'] }} {{ grains['domain'] }}"
+{% endif %}

--- a/salt/default/set_ip_in_etc_hosts.py
+++ b/salt/default/set_ip_in_etc_hosts.py
@@ -43,6 +43,7 @@ def update_hosts_file(fqdn, hostname, repl):
 
 update_hosts_file(fqdn, hostname, "")
 ipv4 = guess_address(fqdn, hostname, socket.AF_INET, "127\\.0\\.", "127.0.1.1")
+# we explicitly exlcude link-local addresses as we currently can't get the interface names
 ipv6 = guess_address(fqdn, hostname, socket.AF_INET6, "(::1$)|(fe[89ab][0-f]:)", "# ipv6 address not found for names:")
 repl = "\n\n{0} {1} {2}\n{3} {4} {5}\n".format(ipv4, fqdn, hostname, ipv6, fqdn, hostname)
 update_hosts_file(fqdn, hostname, repl)


### PR DESCRIPTION
 - uses the short name in `/etc/hostname` and FQDN in `/etc/HOSTNAME` as [per SUSE recommendation in bug 972463](https://bugzilla.suse.com/show_bug.cgi?id=972463#c25). Using the FQDN in `/etc/hostname` is not OK at least in SUSE systems because of a [downstream patch in systemd](https://github.com/openSUSE/systemd/commit/2ce06a5a49)
 - retains a custom Python script in order to write to `/etc/hosts`
   - this is needed to support cases in which a well-configured DNS server is not available, as avahi alone is not sufficient to have both `hostname` and `hostname -f` return correct values. That is true even when enabling the [--enable-search-domains](http://0pointer.de/lennart/projects/nss-mdns/) option in `nss-mdns` and adding the avahi domain to search domains in `resolv.conf`
   - notr that we now avoid using IPv6 link-local addresses as those are not sufficient without an `%interface` part that Python's `socket.getaddrinfo` currently does not return
 - documents choices better
 - has been tested with all supported scenarios through the following one-liner:
```
echo "short: `hostname`"; echo "long: `hostname -f`"; echo "domain: `hostname -d`"; echo "python long: `python -c "import socket; print socket.getfqdn()"`"; echo "/etc/hostname: `cat /etc/hostname`"; echo "/etc/HOSTNAME: `cat /etc/HOSTNAME`"; echo "/etc/hosts: `tail -n2 /etc/hosts`"; ping -c1 `cat /etc/hostname`
```