### PR TITLE
SP3 default for server and proxy on TEST AND HEAD

### DIFF
--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -6,7 +6,7 @@ variable "images" {
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
     "3.1-nightly" = "sles12sp2"
-    "head" = "sles12sp2"
+    "head" = "sles12sp3"
   }
 }
 


### PR DESCRIPTION
SP3 is needed on the proxy HEAD:

```
Problem: nothing provides product(SLES) >= 12.3 needed by product:SUSE-Manager-Proxy-3.2-0.x86_64
```

And while I'm at it, I do the same for TEST.
