### PR TITLE
Add missing parameters to the testsuite controller sample

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -80,4 +80,7 @@ module "head-ctl" {
   minion_configuration = "${module.head-min-sles12sp3.configuration}"
   centos_configuration = "${module.head-min-centos7.configuration}"
   minionssh_configuration = "${module.head-minssh-sles12sp3.configuration}"
+  branch = "default"
+  git_username = "<YOUR_USERNAME>"
+  git_password = "<YOUR_PASSWORD>"
 }


### PR DESCRIPTION
This PR shows the testsuite sample setup with new configuration parameters to access and pull the GitHub testsuite project repository since it's now moved inside a private SUSE GitHub repo and it requires *username* and *password*. 