### PR TITLE
Correct repository URL for 3.1 proxy

### DIFF
--- a/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
+++ b/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.1-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=SUSE-Manager-Proxy-3.1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains["mirror"] | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.0/x86_64/product/
+baseurl=http://{{ grains["mirror"] | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SUSE-Manager-Proxy/3.1/x86_64/product/
 priority=97


### PR DESCRIPTION
3.1 proxy was using a 3.0-based URL.

(New incarnation of https://github.com/moio/sumaform/pull/236 ).