### PR TITLE
Rename $TESTHOST to $SERVER

### DIFF
--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -1,4 +1,6 @@
-export TESTHOST={{ grains.get('server') }}
+export SERVER={{ grains.get('server') }}
+# transition:
+export TESTHOST=$SERVER
 {% if grains.get('proxy') | default(false, true) %}
 export PROXY={{ grains.get('proxy') }}
 {% endif %}
@@ -8,7 +10,7 @@ export SSHMINION={{ grains.get('ssh_minion') }}
 export CENTOSMINION={{ grains.get('centos_minion') }}
 
 # phantomjs needs certificate of suma server to run secure websockets
-if [ ! -f /etc/pki/trust/anchors/$TESTHOST.cert ]; then
-  wget http://$TESTHOST/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$TESTHOST.cert
+if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then
+  wget http://$SERVER/pub/RHN-ORG-TRUSTED-SSL-CERT -O /etc/pki/trust/anchors/$SERVER.cert
   update-ca-certificates
 fi


### PR DESCRIPTION
Rationale: consistency with other variables, simplicity.

$TESTHOST is kept during the transition, a second commit will remove it completely.

See issue https://github.com/SUSE/spacewalk/issues/2459