### PR TITLE
Add new repository for control-node

### DIFF
--- a/salt/controller/repos.d/Devel_Galaxy_cucumber_testsuite.repo
+++ b/salt/controller/repos.d/Devel_Galaxy_cucumber_testsuite.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_cucumber-testsuite]
+name=packages needed for the testsuite (SLE_12_SP1)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/cucumber-testsuite/SLE_12_SP1/

--- a/salt/controller/repos.d/Devel_Galaxy_ruby_test.repo
+++ b/salt/controller/repos.d/Devel_Galaxy_ruby_test.repo
@@ -1,5 +1,0 @@
-[Devel_Galaxy_ruby_test]
-name=Test new ruby packages (SLE_12)
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/ruby:/test/SLE_12/

--- a/salt/controller/repos.sls
+++ b/salt/controller/repos.sls
@@ -1,10 +1,10 @@
 include:
   - default
 
-ruby_test_repo:
+Devel_Galaxy_cucumber_testsuite_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_ruby_test.repo
-    - source: salt://controller/repos.d/Devel_Galaxy_ruby_test.repo
+    - name: /etc/zypp/repos.d/Devel_Galaxy_cucumber_testsuite.repo
+    - source: salt://controller/repos.d/Devel_Galaxy_cucumber_testsuite.repo
     - template: jinja
     - require:
       - sls: default
@@ -21,5 +21,5 @@ refresh_controller_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
     - require:
-      - file: ruby_test_repo
+      - file: Devel_Galaxy_cucumber_testsuite_repo
       - file: sle_12_sp1_sdk_pool

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -278,10 +278,12 @@
   path: /srv/mirror/ibs/Devel:/Galaxy:/Oracle:/SLE11/SLE_11_SP3
   archs: [x86_64]
 
-# Testsuite tools repo
-- url: http://download.suse.de/ibs/Devel:/Galaxy:/ruby:/test/SLE_12
-  path: /srv/mirror/ibs/Devel:/Galaxy:/ruby:/test/SLE_12
+# Testsuite Controller repo
+- url: http://download.suse.de/ibs/Devel:/Galaxy:/cucumber-testsuite/SLE_12_SP1/
+  path: /srv/mirror/ibs/Devel:/Galaxy:/cucumber-testsuite:/SLE_12_SP1
   archs: [x86_64]
+
+# Testsuite dummy packages for testing repo
 - url: http://download.suse.de/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1
   path: /srv/mirror/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1
   archs: [x86_64]


### PR DESCRIPTION
this repository will contain only pkgs that are not rubygems