### PR TITLE
migrate from sles12sp1 to sles12sp3 controller

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -13,7 +13,7 @@ module "controller" {
   source = "../host"
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp1"
+  image = "sles12sp3"
   memory = "${var.memory}"
   running = "${var.running}"
   mac = "${var.mac}"

--- a/salt/controller/repos.d/SLE-12-SP1-SDK-x86_64-Pool.repo
+++ b/salt/controller/repos.d/SLE-12-SP1-SDK-x86_64-Pool.repo
@@ -1,5 +1,0 @@
-[SLE-12-SP1-SDK-x86_64-Pool]
-name=SLE-12-SP1-SDK-x86_64-Pool
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP1/x86_64/product/

--- a/salt/controller/repos.d/SLE-12-SP3-SDK-x86_64-Pool.repo
+++ b/salt/controller/repos.d/SLE-12-SP3-SDK-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-12-SP3-SDK-x86_64-Pool]
+name=SLE-12-SP3-SDK-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("euklid.nue.suse.com", true) }}/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP3/x86_64/product/

--- a/salt/controller/repos.sls
+++ b/salt/controller/repos.sls
@@ -9,10 +9,10 @@ Devel_Galaxy_cucumber_testsuite_repo:
     - require:
       - sls: default
 
-sle_12_sp1_sdk_pool:
+sle_12_sp3_sdk_pool:
   file.managed:
-    - name: /etc/zypp/repos.d/SLE-12-SP1-SDK-x86_64-Pool.repo
-    - source: salt://controller/repos.d/SLE-12-SP1-SDK-x86_64-Pool.repo
+    - name: /etc/zypp/repos.d/SLE-12-SP3-SDK-x86_64-Pool.repo
+    - source: salt://controller/repos.d/SLE-12-SP3-SDK-x86_64-Pool.repo
     - template: jinja
     - require:
       - sls: default
@@ -22,4 +22,4 @@ refresh_controller_repos:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
     - require:
       - file: Devel_Galaxy_cucumber_testsuite_repo
-      - file: sle_12_sp1_sdk_pool
+      - file: sle_12_sp3_sdk_pool

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -51,14 +51,6 @@
   path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12/x86_64/update
   archs: [x86_64]
 
-# SLE 12 SP1 SDK
-- url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP1/x86_64/product
-  path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP1/x86_64/product
-  archs: [x86_64]
-- url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SDK/12-SP1/x86_64/update
-  path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SDK/12-SP1/x86_64/update
-  archs: [x86_64]
-
 # SLES 12 SP1
 - url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product
   path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SERVER/12-SP1/x86_64/product
@@ -81,6 +73,14 @@
   archs: [x86_64]
 - url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update
   path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update
+  archs: [x86_64]
+
+# SLE 12 SP3 SDK
+- url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP3/x86_64/product
+  path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Products/SLE-SDK/12-SP3/x86_64/product
+  archs: [x86_64]
+- url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update
+  path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Updates/SLE-SDK/12-SP3/x86_64/update
   archs: [x86_64]
 
 # SLES 15
@@ -279,8 +279,8 @@
   archs: [x86_64]
 
 # Testsuite Controller repo
-- url: http://download.suse.de/ibs/Devel:/Galaxy:/cucumber-testsuite/SLE_12_SP1/
-  path: /srv/mirror/ibs/Devel:/Galaxy:/cucumber-testsuite:/SLE_12_SP1
+- url: http://download.suse.de/ibs/Devel:/Galaxy:/cucumber-testsuite/SLE_12_SP3/
+  path: /srv/mirror/ibs/Devel:/Galaxy:/cucumber-testsuite:/SLE_12_SP3
   archs: [x86_64]
 
 # Testsuite dummy packages for testing repo


### PR DESCRIPTION
Move controller to sles12sp3


- [x] test that works


I think is better to use sles12sp3 at this point that leap42.3. 

Anyway sles12sp3 has ruby 2.1 has default, and we need ruby 2.2, so we need to find out ruby-devel repo