### PR TITLE
Make CentOS minion optional

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -182,7 +182,9 @@ Please note that `iss_master` is set from `suma21pgm`'s module output variable `
 
 ## Cucumber testsuite
 
-It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the main.tf.libvirt-testsuite.example file. This will create a test server, client and minion instances, plus a coordination node called a `controller` which runs the testsuite.
+It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the main.tf.libvirt-testsuite.example file. This will create a test server, proxy, client and minion instances, plus a coordination node called a `controller` which runs the testsuite.
+
+The proxy and the CentOS minion are optional.
 
 To start the testsuite, use:
 

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -59,6 +59,7 @@ module "head-minssh-sles12sp3" {
   gpg_keys = ["default/gpg_keys/galaxy.key"]
 }
 
+# optional
 module "head-min-centos7" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -56,6 +56,9 @@ variable "minionssh_configuration" {
 variable "centos_configuration" {
   description = "use ${module.<CENTOS_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
+  default = {
+    hostname = "null"
+  }
 }
 
 variable "additional_repos" {

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -1,11 +1,17 @@
 export SERVER={{ grains.get('server') }}
 {% if grains.get('proxy') | default(false, true) %}
 export PROXY={{ grains.get('proxy') }}
+{% else %}
+# no proxy defined
 {% endif %}
 export CLIENT={{ grains.get('client') }}
 export MINION={{ grains.get('minion') }}
 export SSHMINION={{ grains.get('ssh_minion') }}
+{% if grains.get('proxy') | default(false, true) %}
 export CENTOSMINION={{ grains.get('centos_minion') }}
+{% else %}
+# no centos minion defined
+{% endif %}
 
 # phantomjs needs certificate of suma server to run secure websockets
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then


### PR DESCRIPTION
Like for the proxy, one should not need to create all nodes in order to run the testsuite.

This will allow for more lightwight deployments and test suite runs when debugging.

(The names "CENTOS" and "ceos" will probably change to "SLESES" and "sleses" once we get rid of CentOS in favor of SLES ES, but for now we keep consistent with the old naming.)