### PR TITLE
[WIP] Make SSH minion optional

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -184,7 +184,7 @@ Please note that `iss_master` is set from `suma21pgm`'s module output variable `
 
 It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the main.tf.libvirt-testsuite.example file. This will create a test server, proxy, client and minion instances, plus a coordination node called a `controller` which runs the testsuite.
 
-The proxy and the CentOS minion are optional.
+The proxy, the SSH minion, and the CentOS minion are optional. The server, traditional client and normal minion are not.
 
 To start the testsuite, use:
 

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -50,6 +50,7 @@ module "head-min-sles12sp3" {
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
 
+# optional
 module "head-minssh-sles12sp3" {
   source = "./modules/libvirt/host"
   base_configuration = "${module.base.configuration}"

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -20,6 +20,11 @@ variable "git_password" {
   default = "nogit"
 }
 
+variable "branch" {
+  description = "Leave default for automatic selection or specify an existing branch of spacewalk"
+  default = "default"
+}
+
 variable "server_configuration" {
   description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
@@ -38,11 +43,6 @@ variable "client_configuration" {
   type = "map"
 }
 
-variable "branch" {
-  description = "Leave default for automatic selection or specify an existing branch of spacewalk-testsuite-base"
-  default = "default"
-}
-
 variable "minion_configuration" {
   description = "use ${module.<MINION_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
@@ -51,6 +51,9 @@ variable "minion_configuration" {
 variable "minionssh_configuration" {
   description = "use ${module.<MINIONSSH_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
   type = "map"
+  default = {
+    hostname = "null"
+  }
 }
 
 variable "centos_configuration" {

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -1,17 +1,9 @@
 export SERVER={{ grains.get('server') }}
-{% if grains.get('proxy') | default(false, true) %}
-export PROXY={{ grains.get('proxy') }}
-{% else %}
-# no proxy defined
-{% endif %}
+{% if grains.get('proxy') | default(false, true) %}export PROXY={{ grains.get('proxy') }} {% else %}# no proxy defined {% endif %}
 export CLIENT={{ grains.get('client') }}
 export MINION={{ grains.get('minion') }}
-export SSHMINION={{ grains.get('ssh_minion') }}
-{% if grains.get('centos_minion') | default(false, true) %}
-export CENTOSMINION={{ grains.get('centos_minion') }}
-{% else %}
-# no centos minion defined
-{% endif %}
+{% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION={{ grains.get('ssh_minion') }} {% else %}# no SSH minion defined {% endif %}
+{% if grains.get('centos_minion') | default(false, true) %}export CENTOSMINION={{ grains.get('centos_minion') }} {% else %}# no CentOS minion defined {% endif %}
 
 # phantomjs needs certificate of suma server to run secure websockets
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then


### PR DESCRIPTION
Like for the proxy, one should not need to create all nodes in order to run the testsuite.

This will allow for more lightwight deployments and test suite runs when debugging.