### PR TITLE
Remove client tools repos from srv after deployment

### DIFF
--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -179,11 +179,21 @@ filebeat_repo:
 
 remove_client_tools_pool:
   file.absent:
+{% if grains['osmajorrelease'] == '12' %}
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
+{% endif %}
+{% if grains['osmajorrelease'] == '15' %}
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Pool.repo
+{% endif %}
 
 remove_client_tools_update:
   file.absent:
+{% if grains['osmajorrelease'] == '12' %}
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
+{% endif %}
+{% if grains['osmajorrelease'] == '15' %}
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Update.repo
+{% endif %}
 
 refresh_suse_manager_repos:
   cmd.run:

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -177,6 +177,14 @@ filebeat_repo:
       - sls: default
 {% endif %}
 
+remove_client_tools_pool:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
+
+remove_client_tools_update:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
+
 refresh_suse_manager_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh


### PR DESCRIPTION
Just 2 new modules in the standard repos.sls state in suse_manager_server that remove the client tools repositories. I deployed VM's with this state and no errors showed up, all the states were applied successfully, the repos were removed and the double ```zypper patch``` package conflict is not there.
Fixes issue #247