### PR TITLE
Remove the client tools repos for server

### DIFF
--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -177,6 +177,30 @@ filebeat_repo:
       - sls: default
 {% endif %}
 
+{% if grains['osmajorrelease'] == '11' %}
+remove_client_tools_pool:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
+{% elif grains['osmajorrelease'] == '12' %}
+remove_client_tools_pool:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
+{% elif grains['osmajorrelease'] == '15' %}
+remove_client_tools_pool:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Pool.repo
+{% endif %}
+
+{% if grains['osmajorrelease'] == '12' %}
+remove_client_tools_update:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
+{% elif grains['osmajorrelease'] == '15' %}
+remove_client_tools_update:
+  file.absent:
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Update.repo
+{% endif %}
+
 refresh_suse_manager_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh


### PR DESCRIPTION
This is tested with ```head, 3.0-released``` and ```3.1-released```. In head, the repos are not removed because of the [jinja issue](https://github.com/SUSE/spacewalk/issues/2947), on the others the repos are removed. Hopefully as soon as the jinja issue is solved, the repos will also be removed there. In any case, this PR will not break the jenkins build. Fixes #248 

I didn't test the SLE15 or SLE11 cases.