### PR TITLE
Libvirt portability refactoring

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -86,6 +86,33 @@ module "suma3pg" {
 }
 ```
 
+## Custom SSH keys
+
+If you want to use another key for all VMs, specify the path of the public key with `ssh_key_path` into the `base` config. Example:
+
+```hcl
+module "base" {
+  [...]
+  ssh_key_path = "~/.ssh/id_mbologna_terraform.pub"
+  [...]
+}
+```
+
+The `ssh_key_path` option can also be specified on a per-host basis. In this case, the key specified is treated as an additional key, copied to the machine as well as the `ssh_key_path` specified in the `base` section.
+
+If you don't want to copy any ssh key at all (and use passwords instead), just supply an empty file (eg. `ssh_key_path = "/dev/null"`).
+
+## SSH access without specifying a username
+
+You can add the following lines to `~/.ssh/config` to avoid checking hosts and specifying a username:
+
+```
+Host *.tf.local
+StrictHostKeyChecking no
+UserKnownHostsFile=/dev/null
+User root
+```
+
 ## Activation Keys for minions
 
 You can specify an Activation Key string for minions to use at onboarding time to a SUSE Manager Server. An example follows:

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -154,6 +154,6 @@ variable "mirror_private_name" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -79,7 +79,7 @@ variable "channels" {
 }
 
 variable "role"  {
-  description = "Name of the host role, see main.tf.libvirt.example"
+  description = "Name of the host role, see the main.tf example file"
   type = "string"
 }
 

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -27,37 +27,14 @@
 
 ## Accessing VMs
 
-All machines come with avahi's mDNS configured by default on the `.tf.local` domain, and a `root` user with password `linux`.
-Upon provisioning your SSH public key (by default `~/.ssh/id_rsa.pub`) is copied into the remote machine. This means that you can access every machine without supplying any password.
+All machines come with avahi's mDNS configured by default on the `.tf.local` domain, and user `root` with password `linux` accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`).
 
-If you want to use another key for all VMs, specify the path of the public key with `ssh_key_path` into the `base` config. Example:
-
-```hcl
-module "base" {
-  [...]
-  ssh_key_path = "~/.ssh/id_mbologna_terraform.pub"
-  [...]
-}
-```
-
-The `ssh_key_path` option can also be specified on a per-host basis. In this case, the key specified is treated as an additional key, copied to the machine as well as the `ssh_key_path` specified in the `base` section.
-
-If you don't want to copy any ssh key at all (and use passwords instead), just supply an empty file (eg. `ssh_key_path = "/dev/null"`).
-
-Provided your host is on the same network segment of the virtual machines you can access them via:
-
+Thus if your host is on the same network segment of the virtual machines you can simply use:
 ```
 ssh root@moio-suma3pg.tf.local
 ```
 
-You can add the following lines to `~/.ssh/config` to avoid checking hosts and specifying a username:
-
-```
-Host *.tf.local
-StrictHostKeyChecking no
-UserKnownHostsFile=/dev/null
-User root
-```
+If you want to use a different SSH key, or mDNS does not work out of the box, or if you don't want to use mDNS, please check the README_ADVANCED.md and TROUBLESHOOTING.md files.
 
 Web access is on standard ports, so `firefox suma3pg.tf.local` will work as expected. SUSE Manager default user is `admin` with password `admin`.
 

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -12,16 +12,18 @@ resource "libvirt_volume" "volumes" {
 output "configuration" {
   depends_on = ["libvirt_volume.volumes"]
   value = {
-    network_name = "${var.bridge == "" ? var.network_name : ""}"
     cc_username = "${var.cc_username}"
     cc_password = "${var.cc_password}"
     timezone = "${var.timezone}"
-    mirror = "${var.mirror == "" ? "null" : var.mirror}"
     ssh_key_path = "${var.ssh_key_path}"
-    pool = "${var.pool}"
-    bridge = "${var.bridge}"
+    mirror = "${var.mirror == "" ? "null" : var.mirror}"
     use_avahi = "${var.use_avahi}"
     domain = "${var.domain}"
     name_prefix = "${var.name_prefix}"
+
+    // Provider-specific variables
+    pool = "${var.pool}"
+    network_name = "${var.bridge == "" ? var.network_name : ""}"
+    bridge = "${var.bridge}"
   }
 }

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -23,21 +23,6 @@ variable "mirror" {
   default = "null"
 }
 
-variable "pool" {
-  description = "libvirt storage pool name for VM disks"
-  default = "default"
-}
-
-variable "network_name" {
-  description = "libvirt NAT network name for VMs, use empty string for bridged networking"
-  default = "default"
-}
-
-variable "bridge" {
-  description = "a bridge device name available on the libvirt host, leave default for NAT"
-  default = ""
-}
-
 variable "use_avahi" {
   description = "use false only if you use bridged networking with static MACs and an external DHCP"
   default = true
@@ -50,6 +35,23 @@ variable "domain" {
 
 variable "name_prefix" {
   description = "a prefix for all names of objects to avoid collisions. Eg. moio-"
+  default = ""
+}
+
+// Provider-specific variables
+
+variable "pool" {
+  description = "libvirt storage pool name for VM disks"
+  default = "default"
+}
+
+variable "network_name" {
+  description = "libvirt NAT network name for VMs, use empty string for bridged networking"
+  default = "default"
+}
+
+variable "bridge" {
+  description = "a bridge device name available on the libvirt host, leave default for NAT"
   default = ""
 }
 

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -1,13 +1,9 @@
 module "client" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "${var.image}"
   count = "${var.count}"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
@@ -21,7 +17,15 @@ role: client
 for_development_only: ${var.for_development_only}
 for_testsuite_only: ${var.for_testsuite_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
+
 EOF
+
+  // Provider-specific variables
+  image = "${var.image}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 
@@ -19,7 +19,7 @@ variable "version" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -74,7 +74,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -8,11 +8,6 @@ variable "name" {
   type = "string"
 }
 
-variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
-  type = "string"
-}
-
 variable "version" {
   description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
   default = "released"
@@ -53,6 +48,24 @@ variable "count"  {
   default = 1
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
+  type = "string"
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 512
@@ -71,15 +84,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
-}
-
-variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
-  default = []
 }

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -80,6 +80,6 @@ variable "ssh_key_path" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -11,17 +11,13 @@ variable "testsuite-branch" {
 
 module "controller" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp3"
-  memory = "${var.memory}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
-
 
 git_username: ${var.git_username}
 git_password: ${var.git_password}
@@ -34,5 +30,12 @@ centos_minion: ${var.centos_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["version"]) : var.branch}
+
 EOF
+
+  // Provider-specific variables
+  image = "sles12sp3"
+  memory = "${var.memory}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -74,6 +74,14 @@ variable "additional_packages" {
   default = []
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 1024
@@ -87,10 +95,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -90,7 +90,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/evil_minions/main.tf
+++ b/modules/libvirt/evil_minions/main.tf
@@ -1,13 +1,9 @@
 module "evil_minions" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp2"
   count = "${var.count}"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
@@ -20,6 +16,13 @@ slowdown_factor: ${var.slowdown_factor}
 dump: ${base64encode(file(var.dump_file))}
 
 EOF
+
+  // Provider-specific variables
+  image = "sles12sp2"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/evil_minions/variables.tf
+++ b/modules/libvirt/evil_minions/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/evil_minions/variables.tf
+++ b/modules/libvirt/evil_minions/variables.tf
@@ -55,7 +55,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/evil_minions/variables.tf
+++ b/modules/libvirt/evil_minions/variables.tf
@@ -34,6 +34,14 @@ variable "count"  {
   default = 1
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 1024
@@ -52,10 +60,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/grafana/main.tf
+++ b/modules/libvirt/grafana/main.tf
@@ -1,12 +1,8 @@
 module "grafana" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp2"
-  memory = 4096
-  vcpu = 1
-  running = "${var.running}"
-  mac = "${var.mac}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
@@ -16,6 +12,13 @@ version: 3.0-nightly
 role: grafana
 
 EOF
+
+  // Provider-specific variables
+  image = "sles12sp2"
+  memory = 4096
+  vcpu = 1
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -24,7 +24,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/grafana/variables.tf
+++ b/modules/libvirt/grafana/variables.tf
@@ -13,6 +13,14 @@ variable "server_configuration" {
   type = "map"
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
 variable "running" {
   description = "Whether this host should be turned on or off"
   default = true
@@ -21,10 +29,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -59,7 +59,7 @@ variable "grains" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -65,6 +65,6 @@ variable "ssh_key_path" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -8,11 +8,6 @@ variable "name" {
   type = "string"
 }
 
-variable "image" {
-  description = "One of: opensuse422, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
-  type = "string"
-}
-
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default = {}
@@ -26,6 +21,29 @@ variable "additional_packages" {
 variable "count"  {
   description = "number of hosts like this one"
   default = 1
+}
+
+variable "grains" {
+  description = "custom grain string to be added to this host's configuration"
+  default = ""
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: opensuse422, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
+  type = "string"
 }
 
 variable "memory" {
@@ -50,21 +68,5 @@ variable "mac" {
 
 variable "additional_disk" {
   description = "disk block definition(s) to be added to this host"
-  default = []
-}
-
-variable "grains" {
-  description = "custom grain string to be added to this host's configuration"
-  default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
-}
-
-variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -1,13 +1,9 @@
 module "minion" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "${var.image}"
   count = "${var.count}"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
@@ -26,6 +22,13 @@ susemanager:
   activation_key: ${var.activation_key}
 
 EOF
+
+  // Provider-specific variables
+  image = "${var.image}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 
@@ -19,7 +19,7 @@ variable "version" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -85,6 +85,6 @@ variable "ssh_key_path" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -8,11 +8,6 @@ variable "name" {
   type = "string"
 }
 
-variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
-  type = "string"
-}
-
 variable "version" {
   description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
   default = "released"
@@ -58,6 +53,24 @@ variable "count"  {
   default = 1
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
+  type = "string"
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 512
@@ -76,15 +89,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
-}
-
-variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
-  default = []
 }

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -79,7 +79,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/minionswarm/main.tf
+++ b/modules/libvirt/minionswarm/main.tf
@@ -1,13 +1,9 @@
 module "minionswarm" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp1"
   count = "${var.count}"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
@@ -22,6 +18,13 @@ start_delay: ${var.start_delay}
 swap_file_size: ${var.swap_file_size}
 
 EOF
+
+  // Provider-specific variables
+  image = "sles12sp1"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/minionswarm/variables.tf
+++ b/modules/libvirt/minionswarm/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/minionswarm/variables.tf
+++ b/modules/libvirt/minionswarm/variables.tf
@@ -38,14 +38,22 @@ variable "count"  {
   default = 1
 }
 
-variable "memory" {
-  description = "RAM memory in MiB"
-  default = 2048
-}
-
 variable "swap_file_size" {
   description = "Swap file size in MiB"
   default = 8192
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 2048
 }
 
 variable "vcpu" {
@@ -61,10 +69,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/minionswarm/variables.tf
+++ b/modules/libvirt/minionswarm/variables.tf
@@ -64,7 +64,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/mirror/main.tf
+++ b/modules/libvirt/mirror/main.tf
@@ -9,20 +9,11 @@ resource "libvirt_volume" "data_disk" {
 
 module "mirror" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "mirror"
-  image = "opensuse422"
-  memory = 512
-  vcpu = 1
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
-
-  additional_disk = [{
-    volume_id = "${libvirt_volume.data_disk.id}"
-  }]
-
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
@@ -32,4 +23,14 @@ cc_password: ${var.base_configuration["cc_password"]}
 data_disk_device: vdb
 
 EOF
+
+  // Provider-specific variables
+  image = "opensuse422"
+  memory = 512
+  vcpu = 1
+  running = "${var.running}"
+  mac = "${var.mac}"
+  additional_disk = [{
+    volume_id = "${libvirt_volume.data_disk.id}"
+  }]
 }

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -1,6 +1,6 @@
 
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -19,6 +19,14 @@ variable "additional_packages" {
   default = []
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
 variable "data_pool" {
   description = "libvirt storage pool name for this host's data disk"
   default = "default"
@@ -27,10 +35,4 @@ variable "data_pool" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -30,7 +30,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/postgres/main.tf
+++ b/modules/libvirt/postgres/main.tf
@@ -1,12 +1,8 @@
 module "postgres" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "sles12sp1"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
@@ -17,6 +13,13 @@ role: postgres
 for_development_only: True
 
 EOF
+
+  // Provider-specific variables
+  image = "sles12sp1"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -39,7 +39,7 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/postgres/variables.tf
+++ b/modules/libvirt/postgres/variables.tf
@@ -8,11 +8,6 @@ variable "name" {
   type = "string"
 }
 
-variable "memory" {
-  description = "RAM memory in MiB"
-  default = 4096
-}
-
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default = {}
@@ -21,6 +16,19 @@ variable "additional_repos" {
 variable "additional_packages" {
   description = "extra packages to install, see README_ADVANCED.md"
   default = []
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+// Provider-specific variables
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 4096
 }
 
 variable "vcpu" {
@@ -36,10 +44,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -13,14 +13,10 @@ variable "images" {
 
 module "suse_manager" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "${var.image == "default" ? lookup(var.images, var.version) : var.image}"
   count = 1
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
@@ -48,6 +44,13 @@ from_email: ${var.from_email}
 traceback_email: ${var.traceback_email}
 
 EOF
+
+  // Provider-specific variables
+  image = "${var.image == "default" ? lookup(var.images, var.version) : var.image}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -125,6 +125,6 @@ variable "ssh_key_path" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -33,11 +33,6 @@ variable "iss_slave" {
   default = "null"
 }
 
-variable "image" {
-  description = "Leave default for automatic selection or specify sles12sp2 only if version is 3.0-released or 3.0-nightly"
-  default = "default"
-}
-
 variable "for_development_only" {
   description = "whether this host should be pre-configured with settings useful for development, but not necessarily safe in production"
   default = true
@@ -93,6 +88,29 @@ variable "additional_packages" {
   default = []
 }
 
+variable "traceback_email" {
+  description = "recipient email address that will receive errors during usage"
+  default = "null"
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "Leave default for automatic selection or specify sles12sp2 only if version is 3.0-released or 3.0-nightly"
+  default = "default"
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 4096
@@ -111,20 +129,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "traceback_email" {
-  description = "recipient email address that will receive errors during usage"
-  default = "null"
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
-}
-
-variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
-  default = []
 }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -119,7 +119,7 @@ variable "traceback_email" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -12,14 +12,10 @@ variable "images" {
 
 module "suse_manager_proxy" {
   source = "../host"
+
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
-  image = "${lookup(var.images, var.version)}"
   count = "${var.count}"
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
@@ -34,6 +30,13 @@ for_development_only: ${var.for_development_only}
 use_unreleased_updates: ${var.use_unreleased_updates}
 
 EOF
+
+  // Provider-specific variables
+  image = "${lookup(var.images, var.version)}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
 }
 
 output "configuration" {

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -70,6 +70,6 @@ variable "ssh_key_path" {
 }
 
 variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
   default = []
 }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -1,5 +1,5 @@
 variable "base_configuration" {
-  description = "use ${module.base.configuration}, see main.tf.libvirt.example"
+  description = "use ${module.base.configuration}, see the main.tf example file"
   type = "map"
 }
 

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -64,10 +64,11 @@ variable "mac" {
 }
 
 variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see libvirt/README.md"
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
+
 variable "gpg_keys" {
   description = "salt/ relative paths of gpg keys that you want to add to your VMs, see libvirt/README.md"
   default = []

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -43,6 +43,19 @@ variable "count"  {
   default = 1
 }
 
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 1024
@@ -61,15 +74,4 @@ variable "running" {
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
-}
-
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
-  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
-}
-
-variable "gpg_keys" {
-  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
-  default = []
 }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -14,7 +14,7 @@ variable "version" {
 }
 
 variable "server_configuration" {
-  description = "use ${module.<SERVER_NAME>.configuration}, see see ADVANCED_MAIN_TF.md"
+  description = "use ${module.<SERVER_NAME>.configuration}, see README_ADVANCED.md"
   type = "map"
 }
 


### PR DESCRIPTION
This is to regroup variables so that the distinction between cross-backend and backend-specific properties is clear.

Aim is to make future portability to backends easier.