### PR TITLE
Fix: mirror: start crontab

### DIFF
--- a/salt/mirror/init.sls
+++ b/salt/mirror/init.sls
@@ -55,6 +55,11 @@ mirror_script:
       - archive: minima
       - file: minima_configuration
       - file: mirror_script
+  service.running:
+    - name: cron
+    - enable: True
+    - watch:
+      - file: /root/mirror.sh
 
 mirror_partition:
   cmd.run:


### PR DESCRIPTION
Ever wondered why you setup a mirror and mirror script does not run,
even if cronjob time is already passed?
In our kiwi distribution cron.service is not started (but enabled),
so you either start cron (this PR does it) or reboot the machine.

