### PR TITLE
Add centos7_openstack_support via packer

### DIFF
--- a/modules/openstack/base/variables.tf
+++ b/modules/openstack/base/variables.tf
@@ -42,13 +42,14 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to Glance, leave default for all"
-  default = ["opensuse423",  "sles12sp3",  "sles12sp2",  "sles12sp1",   "sles12",  "sles11sp4", "sles11sp3", "sles15beta4"]
+  default = ["centos7", "opensuse423",  "sles12sp3",  "sles12sp2",  "sles12sp1",   "sles12",  "sles11sp4", "sles11sp3", "sles15beta4"]
   type = "list"
 }
 
 variable "image_locations" {
   description = "list of locations to download images, override to add custom ones"
   default = {
+    centos7 = "http://w3.nue.suse.com/~smoioli/sumaform-images/openstack/centos7.qcow2"
     opensuse423 = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/openstack/images/opensuse423.x86_64.qcow2"
     sles11sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles11sp3.x86_64.qcow2"
     sles11sp4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles11sp4.x86_64.qcow2"

--- a/modules/openstack/host/main.tf
+++ b/modules/openstack/host/main.tf
@@ -37,6 +37,12 @@ resource "openstack_compute_instance_v2" "instance" {
     access_network = true
     name = "fixed"
   }
+
+  user_data = <<EOF
+#cloud-config
+ssh_pwauth: 1
+EOF
+
 }
 
 resource "openstack_blockstorage_volume_v2" "extra_volume" {

--- a/packer/centos7openstack.json
+++ b/packer/centos7openstack.json
@@ -1,0 +1,47 @@
+{
+  "provisioners": [{
+   "type": "shell",
+   "scripts": [
+      "scripts/base.sh",
+      "scripts/cloud.sh",
+      "scripts/cleanup.sh"
+    ],
+    "override": {
+      "centos7": {
+        "execute_command": "sh '{{.Path}}'"
+      }
+    }
+  }],
+  "builders": [{
+      "name": "centos7",
+      "type": "qemu",
+      "iso_checksum": "bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5",
+      "iso_checksum_type": "sha256",
+      "iso_url": "http://mirror2.hs-esslingen.de/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso",
+      "ssh_wait_timeout": "30s",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 4000,
+      "format": "qcow2",
+      "qemuargs": [
+        [ "-m", "1024M" ],
+        ["-machine", "type=pc,accel=kvm"],
+        ["-device", "virtio-net-pci,netdev=user.0"]
+      ],
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "http_port_min": 10082,
+      "http_port_max": 10089,
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "root",
+      "ssh_password": "linux",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "vm_name": "centos7",
+      "disk_interface": "virtio",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_centos7.cfg<enter><wait>"
+      ]
+    }]
+}

--- a/packer/centos7openstack.json
+++ b/packer/centos7openstack.json
@@ -20,7 +20,7 @@
       "iso_url": "http://mirror2.hs-esslingen.de/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1708.iso",
       "ssh_wait_timeout": "30s",
       "shutdown_command": "shutdown -P now",
-      "disk_size": 4000,
+      "disk_size": 5000,
       "format": "qcow2",
       "qemuargs": [
         [ "-m", "1024M" ],

--- a/packer/scripts/cloud.sh
+++ b/packer/scripts/cloud.sh
@@ -1,0 +1,27 @@
+# Configure serial console
+yum -y install grub2-tools
+
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/sec-GRUB_2_over_Serial_Console.html#sec-Configuring_GRUB_2
+cat > /etc/default/grub <<EOF
+GRUB_DEFAULT=0
+GRUB_HIDDEN_TIMEOUT=0
+GRUB_HIDDEN_TIMEOUT_QUIET=true
+GRUB_TIMEOUT=1
+GRUB_DISTRIBUTOR="$(sed 's, release .*$,,g' /etc/system-release)"
+GRUB_DEFAULT=saved
+GRUB_DISABLE_SUBMENU=true
+GRUB_TERMINAL=serial
+GRUB_SERIAL_COMMAND="serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1"
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty0 console=ttyS0,115200n8"
+GRUB_TERMINAL_OUTPUT="console"
+GRUB_DISABLE_RECOVERY="true"
+EOF
+
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+# remove uuid
+sed -i '/UUID/d' /etc/sysconfig/network-scripts/ifcfg-e*
+sed -i '/HWADDR/d' /etc/sysconfig/network-scripts/ifcfg-e*
+
+# Installs cloudinit, epel is required
+yum -y install cloud-init


### PR DESCRIPTION
Add centos7_image for openstack backend.

# Task:

- [x] packer build should pass

- [x] image should work (deploy boot and sshable on openstack)

- [ ]  do final test with working image with ssh enabled via pwd