### PR TITLE
[WIP] Add centos7 to sumaform, increase disk size for server

### DIFF
--- a/modules/openstack/base/variables.tf
+++ b/modules/openstack/base/variables.tf
@@ -42,13 +42,14 @@ variable "name_prefix" {
 
 variable "images" {
   description = "list of images to be uploaded to Glance, leave default for all"
-  default = ["opensuse423",  "sles12sp3",  "sles12sp2",  "sles12sp1",   "sles12",  "sles11sp4", "sles11sp3", "sles15beta4"]
+  default = ["centos7", "opensuse423", "sles11sp3", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles15beta4"]
   type = "list"
 }
 
 variable "image_locations" {
   description = "list of locations to download images, override to add custom ones"
   default = {
+    centos7 = "http://w3.nue.suse.com/~smoioli/sumaform-images/centos7_v2.qcow2"
     opensuse423 = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/openstack/images/opensuse423.x86_64.qcow2"
     sles11sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles11sp3.x86_64.qcow2"
     sles11sp4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles11sp4.x86_64.qcow2"

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -42,7 +42,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
+  description = "One of: centos7, opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
   type = "string"
 }
 

--- a/packer/centos6.json
+++ b/packer/centos6.json
@@ -20,7 +20,7 @@
       "iso_url": "http://ftp.tu-chemnitz.de/pub/linux/centos/6.8/isos/x86_64/CentOS-6.8-x86_64-minimal.iso",
       "ssh_wait_timeout": "30s",
       "shutdown_command": "shutdown -P now",
-      "disk_size": 104858,
+      "disk_size": 204800,
       "format": "qcow2",
       "qemuargs": [
         [ "-m", "1024M" ],

--- a/packer/centos7.json
+++ b/packer/centos7.json
@@ -20,7 +20,7 @@
       "iso_url": "http://mirror2.hs-esslingen.de/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1611.iso",
       "ssh_wait_timeout": "30s",
       "shutdown_command": "shutdown -P now",
-      "disk_size": 104858,
+      "disk_size": 204800,
       "format": "qcow2",
       "qemuargs": [
         [ "-m", "1024M" ],

--- a/salt/mirror/init.sls
+++ b/salt/mirror/init.sls
@@ -55,6 +55,11 @@ mirror_script:
       - archive: minima
       - file: minima_configuration
       - file: mirror_script
+  service.running:
+    - name: cron
+    - enable: True
+    - watch:
+      - file: /root/mirror.sh
 
 mirror_partition:
   cmd.run:

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -269,8 +269,8 @@
   archs: [x86_64]
 
 # SUSE Manager TEST devel
-- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP2
-  path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP2
+- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP3
+  path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP3
   archs: [x86_64]
 
 # Oracle server

--- a/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_TEST.repo
+++ b/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_TEST.repo
@@ -1,6 +1,6 @@
 [Devel_Galaxy_Manager_TEST]
-name=Devel Project for SUSE Manager TEST (SLE_12_SP2)
+name=Devel Project for SUSE Manager TEST (SLE_12_SP3)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP2/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP3/
 priority=95


### PR DESCRIPTION
* Add centos image for openstack
  Please notice I used same private URL as for libvirt. Feel free to adjust.
* Use 200 GiB default for server to be aligned with libvirt images

