### PR TITLE
Support SUSE Manager on openSUSE

### DIFF
--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -107,7 +107,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "Leave default for automatic selection or specify sles12sp2 only if version is 3.0-released or 3.0-nightly"
+  description = "Leave default for automatic selection or specify an OS supported by the specified product version"
   default = "default"
 }
 

--- a/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+++ b/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_Head]
+name=Devel Project for SUSE Manager Head (Leap)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/openSUSE_Leap_42.3/
+priority=96

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -56,6 +56,23 @@ suse_manager_update_repo:
 {% endif %}
 
 {% if 'head' in grains['version'] %}
+{% if grains['osfullname'] == 'Leap' %}
+suse_manager_pool_repo:
+  file.touch:
+    - name: /tmp/no_pool_channel_needed
+
+suse_manager_update_repo:
+  file.touch:
+    - name: /tmp/no_update_channel_needed
+
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+    - source: salt://suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+    - template: jinja
+    - require:
+      - sls: default
+{% else %}
 suse_manager_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
@@ -75,6 +92,7 @@ suse_manager_devel_repo:
     - template: jinja
     - require:
       - sls: default
+{% endif %}
 {% endif %}
 
 {% if '2.1-nightly' in grains['version'] %}


### PR DESCRIPTION
No other changes should be needed on the sumaform side.

I will merge this as soon as the product works minimally.


`main.tf` example:
```hcl
module "opensuma" {
  source = "./modules/libvirt/suse_manager"
  base_configuration = "${module.base.configuration}"

  name = "opensuma"
  version = "head"
  image = "opensuse423"
}
```


CC @juliogonzalez