### PR TITLE
Making SUSE ECP Cloud the default

### DIFF
--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -21,9 +21,9 @@ module "base" {
   // name_prefix = ""
   // timezone = "Europe/Berlin"
 
-  // uncomment the following if you are targeting the SUSE internal "ECP" Cloud
-  // mirror = "mirror.tf.local"
-  // use_shared_resources = true
+  // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud 
+  mirror = "mirror.tf.local"
+  use_shared_resources = true
 }
 
 module "srv" {

--- a/main.tf.openstack.example
+++ b/main.tf.openstack.example
@@ -21,9 +21,9 @@ module "base" {
   // name_prefix = ""
   // timezone = "Europe/Berlin"
 
-  // uncomment the following if you are targeting the SUSE internal "ECP" Cloud
-  // mirror = "mirror.tf.local"
-  // use_shared_resources = true
+  // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud
+  mirror = "mirror.tf.local"
+  use_shared_resources = true
 }
 
 module "suma3pg" {


### PR DESCRIPTION
Since the main target audience are probably SUSE people, you might consider changing this.

This way deployments to the ECP cloud are working without modification of the
example config.