### PR TITLE
add python-pip trusted-host flag

### DIFF
--- a/salt/locust/init.sls
+++ b/salt/locust/init.sls
@@ -13,6 +13,7 @@ locust_prerequisites:
 locustio:
   pip.installed:
     - name: locustio == 0.8.1
+    - trusted_host: pypi.python.org
     - require:
       - pkg: pip
       - pkg: locust_prerequisites
@@ -20,6 +21,7 @@ locustio:
 prometheus_client:
   pip.installed:
    - name: prometheus-client == 0.1.1
+   - trusted_host: pypi.python.org
    - require:
      - pkg: pip
      - pkg: locust_prerequisites


### PR DESCRIPTION
this is needed for cloud vms

We can use pip and downlad pkg on cloud