### PR TITLE
Testsuite: clarify need for credentials

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -24,6 +24,7 @@ module "ctl" {
   centos_configuration = "${module.min-centos7.configuration}"         // optional
   minionssh_configuration = "${module.minssh-sles12sp3.configuration}" // optional
   branch = "default"
+  // credentials available in https://gitlab.suse.de/galaxy/sumaform-test-runner/blob/master/31/main-full.tf
   git_username = ...
   git_password = ...
 }

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -36,6 +36,7 @@ module "ctl" {
   centos_configuration = "${module.min-centos7.configuration}"         // optional
   minionssh_configuration = "${module.minssh-sles12sp3.configuration}" // optional
   branch = "default"
+  // credentials available in https://gitlab.suse.de/galaxy/sumaform-test-runner/blob/master/31/main-full.tf
   git_username = ...
   git_password = ...
 }

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -11,13 +11,11 @@ variable "name" {
 variable "git_username" {
   description = "username for GitHub"
   type = "string"
-  default = "nogit"
 }
 
 variable "git_password" {
   description = "password for GitHub"
   type = "string"
-  default = "nogit"
 }
 
 variable "branch" {

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -11,13 +11,11 @@ variable "name" {
 variable "git_username" {
   description = "username for GitHub"
   type = "string"
-  default = "nogit"
 }
 
 variable "git_password" {
   description = "password for GitHub"
   type = "string"
-  default = "nogit"
 }
 
 variable "branch" {


### PR DESCRIPTION
We had users stumbling upon the problem that creating the controller "takes forever" - git waits for user input.

I made the credentials passwords mandatory, so they can't be skipped at plan/apply time.

Additionally, since this does not work for users with 2FA, I added a link to where users can find the credentials we use for CI.