### PR TITLE
Support SUSE Manager on openSUSE

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -166,7 +166,7 @@ module "min" {
 
 ## Change the base OS for supported SUSE Manager versions
 
-You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1`, `sles12sp2` and `sles12sp3`.
+You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1`, `sles12sp2` and `sles12sp3`. `head` can also use `opensuse423`
 
 The following example creates a SUSE Manager server using "nightly" packages from version 3 based on SLES 12 SP2:
 

--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -166,7 +166,7 @@ module "min" {
 
 ## Change the base OS for supported SUSE Manager versions
 
-You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Currently this only applies to versions `3.0` and up that can switch between `sles12sp1`, `sles12sp2` and `sles12sp3`. `head` can also use `opensuse423`
+You can specifiy a base OS for `suse_manager` modules by specifying an `image` variable. There is a default selection if nothing is specified. Please note that not all SUSE Manager versions support all OSs, refer to official documentation to select a compatible OS. In particular, `opensuse423` can presently only be used for the `head` version.
 
 The following example creates a SUSE Manager server using "nightly" packages from version 3 based on SLES 12 SP2:
 

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -157,7 +157,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "Leave default for automatic selection or specify sles12sp2 only if version is 3.0-released or 3.0-nightly"
+  description = "Leave default for automatic selection or specify an OS supported by the specified product version"
   default = "default"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -36,7 +36,7 @@ use_unreleased_updates: ${var.use_unreleased_updates}
 EOF
 
   // Provider-specific variables
-  image = "${lookup(var.images, var.version)}"
+  image = "${var.image == "default" ? lookup(var.images, var.version) : var.image}"
   memory = "${var.memory}"
   vcpu = "${var.vcpu}"
   running = "${var.running}"

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -76,6 +76,11 @@ variable "gpg_keys" {
 
 // Provider-specific variables
 
+variable "image" {
+  description = "Leave default for automatic selection or specify an OS supported by the specified product version"
+  default = "default"
+}
+
 variable "memory" {
   description = "RAM memory in MiB"
   default = 1024

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -36,7 +36,7 @@ use_unreleased_updates: ${var.use_unreleased_updates}
 EOF
 
   // Provider-specific variables
-  image = "${lookup(var.images, var.version)}"
+  image = "${var.image == "default" ? lookup(var.images, var.version) : var.image}"
   flavor = "${var.flavor}"
   root_volume_size = "${var.root_volume_size}"
   floating_ips = "${var.floating_ips}"

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -76,6 +76,11 @@ variable "gpg_keys" {
 
 // Provider-specific variables
 
+variable "image" {
+  description = "Leave default for automatic selection or specify sles12sp2 only if version is 3.0-released or 3.0-nightly"
+  default = "default"
+}
+
 variable "flavor" {
   description = "OpenStack flavor"
   default = "m1.small"

--- a/salt/default/repos.d/systemsmanagement-saltstack_products-next.repo
+++ b/salt/default/repos.d/systemsmanagement-saltstack_products-next.repo
@@ -1,0 +1,7 @@
+[systemsmanagement_saltstack_products_next]
+name=Next salt version to go into :products (openSUSE_Leap_42.3)
+type=rpm-md
+baseurl=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/openSUSE_Leap_42.3/
+gpgcheck=1
+gpgkey=http://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/openSUSE_Leap_42.3/repodata/repomd.xml.key
+enabled=1

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -27,8 +27,10 @@ os_update_repo:
     - template: jinja
 
 tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
+  file.managed:
+    - name: /etc/zypp/repos.d/systemsmanagement-saltstack_products-next.repo
+    - source: salt://default/repos.d/systemsmanagement-saltstack_products-next.repo
+    - template: jinja
 
 tools_update_repo:
   file.touch:
@@ -303,12 +305,21 @@ tools_devel_repo:
 
 
 allow_vendor_changes:
+  {% if grains['osfullname'] == 'Leap' %}
+  file.managed:
+    - name: /etc/zypp/vendors.d/opensuse
+    - makedirs: True
+    - contents: |
+        [main]
+        vendors = openSUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
+  {% else %}
   file.managed:
     - name: /etc/zypp/vendors.d/suse
     - makedirs: True
     - contents: |
         [main]
         vendors = SUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
+  {% endif %}
 
 refresh_default_repos:
   cmd.run:

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -155,14 +155,24 @@
 #  path: /srv/mirror/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15:/x86_64/update
 #  archs: [x86_64]
 
-# SUSE Manager Head
+# SUSE Manager Head (SLE12-SP3)
 - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1
   path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1
   archs: [x86_64]
 
-# SUSE Manager Head Proxy
+# SUSE Manager Head Proxy (SLE12-SP3)
 - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
   path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
+  archs: [x86_64]
+
+# SUSE Manager Head (openSUSE Leap 42.3)
+- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE42.3-SUSE-Manager-Server-3.2-POOL-x86_64-Media1/
+  path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE_Leap_42.3-SUSE-Manager-Server-3.2-POOL-x86_64-Media1
+  archs: [x86_64]
+
+# SUSE Manager Head Proxy (openSUSE Leap 42.3)
+- url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE_Leap_42.3-SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
+  path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE_Leap_42.3-SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
   archs: [x86_64]
 
 # SUSE Manager 3.0 devel
@@ -267,4 +277,9 @@
 # security:logging (filebeat)
 - url: http://download.opensuse.org/repositories/security:/logging/SLE_12_SP2
   path: /srv/mirror/repositories/security:/logging/SLE_12_SP2
+  archs: [x86_64]
+
+# systemsmanagement:saltstack:products:next (salt for openSUSE 42.3)
+- url: https://download.opensuse.org/repositories/systemsmanagement:/saltstack:/products:/next/openSUSE_Leap_42.3/
+- path: /srv/mirror/repositories/systemsmanagement:/saltstack:/products:/next/openSUSE_Leap_42.3/
   archs: [x86_64]

--- a/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+++ b/salt/suse_manager_proxy/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_Head_Leap]
+name=Devel Project for SUSE Manager Head (openSUSE Leap 42.3)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/openSUSE_Leap_42.3/
+priority=96

--- a/salt/suse_manager_proxy/repos.d/Leap-SUSE-Manager-Proxy-Head-x86_64-Pool.repo
+++ b/salt/suse_manager_proxy/repos.d/Leap-SUSE-Manager-Proxy-Head-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[Leap-SUSE-Manager-Proxy-Head-x86_64-Pool]
+name=SUSE-Manager-Proxy-Head-x86_64-Pool (openSUSE Leap 42.3)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE42.3-SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1/
+priority=97

--- a/salt/suse_manager_proxy/repos.sls
+++ b/salt/suse_manager_proxy/repos.sls
@@ -38,6 +38,27 @@ suse_manager_proxy_update_repo:
 {% endif %}
 
 {% if 'head' in grains['version'] %}
+{% if grains['osfullname'] == 'Leap' %}
+suse_manager_proxy_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-Head-x86_64-Pool.repo
+    - source: salt://suse_manager_proxy/repos.d/Leap-SUSE-Manager-Proxy-Head-x86_64-Pool.repo
+    - template: jinja
+    - require:
+      - sls: default
+
+suse_manager_proxy_update_repo:
+  file.touch:
+    - name: /tmp/no_update_channel_needed
+
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head.repo
+    - source: salt://suse_manager_proxy/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+    - template: jinja
+    - require:
+      - sls: default
+{% else %}
 suse_manager_proxy_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-Head-x86_64-Pool.repo
@@ -57,6 +78,7 @@ suse_manager_devel_repo:
     - template: jinja
     - require:
       - sls: default
+{% endif %}
 {% endif %}
 
 {% if '3.0-nightly' in grains['version'] %}

--- a/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+++ b/salt/suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_Head_Leap]
+name=Devel Project for SUSE Manager Head  (openSUSE Leap 42.3)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/openSUSE_Leap_42.3/
+priority=96

--- a/salt/suse_manager_server/repos.d/Leap-SUSE-Manager-Head-x86_64-Pool.repo
+++ b/salt/suse_manager_server/repos.d/Leap-SUSE-Manager-Head-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[Leap-SUSE-Manager-Head-x86_64-Pool]
+name=SUSE-Manager-Head-x86_64-Pool (openSUSE Leap 42.3)
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE42.3-SUSE-Manager-Server-3.2-POOL-x86_64-Media1/
+priority=97

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -38,6 +38,25 @@ suse_manager_update_repo:
 {% endif %}
 
 {% if 'head' in grains['version'] %}
+{% if grains['osfullname'] == 'Leap' %}
+suse_manager_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
+    - source: salt://suse_manager_server/repos.d/Leap-SUSE-Manager-Head-x86_64-Pool.repo
+    - template: jinja
+    - require:
+      - sls: default
+suse_manager_update_repo:
+  file.touch:
+    - name: /tmp/no_update_channel_needed
+suse_manager_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+    - source: salt://suse_manager_server/repos.d/Devel_Galaxy_Manager_Head_Leap.repo
+    - template: jinja
+    - require:
+      - sls: default
+{% else %}
 suse_manager_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
@@ -57,6 +76,7 @@ suse_manager_devel_repo:
     - template: jinja
     - require:
       - sls: default
+{% endif %}
 {% endif %}
 
 {% if '3.0-nightly' in grains['version'] %}


### PR DESCRIPTION
Superseeds #272 (after the last sumaform changes I was afraid of having to resolve a lot of merge conflicts, so just in case...)

```main.tf``` example:

```
module "server" {
  source = "./modules/libvirt/suse_manager"
  base_configuration = "${module.base.configuration}"

  name = "server"
  version = "head"
  image = "opensuse423"
  // see modules/libvirt/suse_manager/variables.tf for possible values
}

module "proxy" {
  source = "./modules/libvirt/suse_manager_proxy"
  base_configuration = "${module.base.configuration}"
  image = "opensuse423"
  name = "proxy"
  version = "head"
  server_configuration = "${module.server.configuration}"
}

```