### PR TITLE
add set -e for having in CI the exact retcode

### DIFF
--- a/salt/controller/run-testsuite.sh
+++ b/salt/controller/run-testsuite.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+set -e
+
 cd /root/spacewalk/testsuite
 
 if [ -z "$1" ]; then
    rake
 fi
 # this to run cucumber features in parallel
-if [ $1 = "parallel" ]; then
+if [[ $1 = "parallel" ]]; then
    rake core
    rake secondary_parallel
    rake post_run


### PR DESCRIPTION
running at moment run-testsuite we don't have the retcode according to failure