### PR TITLE
Remove useless variable from examples

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -52,7 +52,6 @@ module "srv" {
 module "cli-sles12sp3" {
   source = "./modules/libvirt/client"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" }
@@ -63,7 +62,6 @@ module "cli-sles12sp3" {
 module "min-sles12sp3" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" }
@@ -85,7 +83,6 @@ module "minssh-sles12sp3" {
 module "min-centos7" {
   source = "./modules/libvirt/minion"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "min-centos7"
   image = "centos7"
   server_configuration = { hostname = "srv.tf.local" }

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -65,7 +65,6 @@ module "srv" {
 module "cli-sles12sp3" {
   source = "./modules/openstack/client"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" }
@@ -76,7 +75,6 @@ module "cli-sles12sp3" {
 module "min-sles12sp3" {
   source = "./modules/openstack/minion"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
   server_configuration = { hostname = "srv.tf.local" }
@@ -98,7 +96,6 @@ module "minssh-sles12sp3" {
 module "min-centos7" {
   source = "./modules/openstack/minion"
   base_configuration = "${module.base.configuration}"
-  version = "3.1-nightly"
   name = "min-centos7"
   image = "centos7"
   server_configuration = { hostname = "srv.tf.local" }


### PR DESCRIPTION
`version` variable is useless for clients, it matters only for SUSE Manager server and proxy.