### PR TITLE
configure grain for use_unreleased_updates in host

### DIFF
--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -8,6 +8,7 @@ module "client" {
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
   ssh_key_path = "${var.ssh_key_path}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
   grains = <<EOF
 
 version: ${var.version}
@@ -16,7 +17,6 @@ server: ${var.server_configuration["hostname"]}
 role: client
 auto_register: ${var.auto_register}
 testsuite: ${var.base_configuration["testsuite"]}
-use_unreleased_updates: ${var.use_unreleased_updates}
 
 EOF
 

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -59,6 +59,7 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
 gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
+use_unreleased_updates: ${var.use_unreleased_updates}
 ${var.grains}
 
 EOF

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -8,6 +8,7 @@ module "minion" {
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
   ssh_key_path = "${var.ssh_key_path}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
   grains = <<EOF
 
 version: ${var.version}
@@ -16,7 +17,6 @@ server: ${var.server_configuration["hostname"]}
 role: minion
 auto_connect_to_master: ${var.auto_connect_to_master}
 testsuite: ${var.base_configuration["testsuite"]}
-use_unreleased_updates: ${var.use_unreleased_updates}
 
 susemanager:
   activation_key: ${var.activation_key}

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -19,6 +19,7 @@ module "suse_manager" {
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
   grains = <<EOF
 
 version: ${var.version}
@@ -45,7 +46,6 @@ create_sample_activation_key: ${var.create_sample_activation_key}
 create_sample_bootstrap_script: ${var.create_sample_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
 testsuite: ${var.base_configuration["testsuite"]}
-use_unreleased_updates: ${var.use_unreleased_updates}
 auto_accept: ${var.auto_accept}
 monitored: ${var.monitored}
 log_server: ${var.log_server}

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -18,6 +18,7 @@ module "suse_manager_proxy" {
   additional_packages = "${var.additional_packages}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
   grains = <<EOF
 
 version: ${var.version}
@@ -31,7 +32,6 @@ server_username: ${var.server_configuration["username"]}
 server_password: ${var.server_configuration["password"]}
 generate_bootstrap_script: ${var.generate_bootstrap_script}
 publish_private_ssl_key: ${var.publish_private_ssl_key}
-use_unreleased_updates: ${var.use_unreleased_updates}
 
 EOF
 


### PR DESCRIPTION
To be able to define "use_unreleased_updates" also for ssh minions we need to configure the grain
in "host"