### PR TITLE
Add support for 3.2-released

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -8,7 +8,8 @@ Some modules have a ``version`` variable that determines the software version. S
 
 Legal values for released software are:
  * `3.0-released` (latest released Maintenance Update for SUSE Manager 3.0 and Tools)
- * `3.1-released` (latest released alpha/beta/gold master candidate for SUSE Manager 3.1 and Tools)
+ * `3.1-released` (latest released Maintenance Update for SUSE Manager 3.1 and Tools)
+ * `3.2-released` (latest released alpha/beta/gold master candidate for SUSE Manager 3.2 and Tools)
 
 Legal values for work-in-progress software are:
  * `3.0-nightly` (corresponds to the Build Service project Devel:Galaxy:Manager:3.0)

--- a/modules/aws/host/variables.tf
+++ b/modules/aws/host/variables.tf
@@ -64,7 +64,7 @@ variable "name_prefix" {
 }
 
 variable "version" {
-  description = "Main product version (eg. 3.1-released, 3.0-nightly, head)"
+  description = "Main product version (eg. 3.2-released, 3.1-nightly, head)"
   default = "null"
 }
 

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -4,6 +4,7 @@ variable "testsuite-branch" {
     "3.0-nightly" = "Manager-3.0"
     "3.1-released" = "Manager-3.1"
     "3.1-nightly" = "Manager-3.1"
+    "3.2-released" = "Manager"
     "head" = "Manager"
     "test" = "Manager"
   }

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -4,6 +4,7 @@ variable "images" {
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
     "3.1-nightly" = "sles12sp2"
+    "3.2-released" = "sles12sp3"
     "head" = "sles12sp3"
     "test" = "sles12sp3"
   }

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head, test"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, head, test"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -4,6 +4,7 @@ variable "images" {
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
     "3.1-nightly" = "sles12sp2"
+    "3.2-released" = "sles12sp3"
     "head" = "sles12sp3"
   }
 }

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, head"
   type = "string"
 }
 

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -4,6 +4,7 @@ variable "testsuite-branch" {
     "3.0-nightly" = "Manager-3.0"
     "3.1-released" = "Manager-3.1"
     "3.1-nightly" = "Manager-3.1"
+    "3.2-released" = "Manager"
     "head" = "Manager"
     "test" = "Manager"
   }

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -4,6 +4,7 @@ variable "images" {
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
     "3.1-nightly" = "sles12sp2"
+    "3.2-released" = "sles12sp3"
     "head" = "sles12sp3"
     "test" = "sles12sp3"
   }

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head, test"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, head, test"
   type = "string"
 }
 

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -4,6 +4,7 @@ variable "images" {
     "3.0-nightly" = "sles12sp1"
     "3.1-released" = "sles12sp2"
     "3.1-nightly" = "sles12sp2"
+    "3.2-released" = "sles12sp3"
     "head" = "sles12sp3"
   }
 }

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, head"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-released, head"
   type = "string"
 }
 

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64]
+name=Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+priority=98

--- a/salt/default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+++ b/salt/default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
@@ -1,0 +1,6 @@
+[Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64]
+name=Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12:/Update:/Products:/ManagerToolsBeta:/Update/standard
+priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
@@ -1,0 +1,6 @@
+[SLE-Manager-Tools-RES-7-Beta-x86_64]
+name=SLE-Manager-Tools-RES-7-Beta-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -1,5 +1,5 @@
-[Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64]
-name=Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64
+[SLE-Manager-Tools-SLE-11-Beta-x86_64]
+name=SLE-Manager-Tools-SLE-11-Beta-x86_64
 type=rpm-md
 enabled=1
 baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-12-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12:/Update:/Products:/ManagerToolsBeta:/Update/standard
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE12/x86_64
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-12-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE12/x86_64
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -1,5 +1,5 @@
-[Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64]
-name=Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64
+[SLE-Manager-Tools-SLE-12-Beta-x86_64]
+name=SLE-Manager-Tools-SLE-12-Beta-x86_64
 type=rpm-md
 enabled=1
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12:/Update:/Products:/ManagerToolsBeta:/Update/standard

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -74,7 +74,15 @@ tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_repo_needed
 
-{% if 'released' in grains.get('version') | default('released', true) %}
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
 
 tools_devel_repo:
   file.touch:
@@ -211,7 +219,15 @@ tools_update_repo:
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
 
-{% if 'released' in grains.get('version') | default('released', true) %}
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
 
 tools_devel_repo:
   file.touch:
@@ -361,7 +377,16 @@ suse_res7_key:
     - watch:
       - file: suse_res7_key
 
-{% if 'head' in grains.get('version') | default('', true) %}
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+tools_update_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+    - source: salt://default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+    - template: jinja
+    - require:
+      - cmd: galaxy_key
+
+{% elif 'head' in grains.get('version') | default('', true) %}
 tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo
@@ -369,6 +394,7 @@ tools_update_repo:
     - template: jinja
     - require:
       - cmd: galaxy_key
+
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
 tools_update_repo:
   file.managed:
@@ -377,6 +403,7 @@ tools_update_repo:
     - template: jinja
     - require:
       - cmd: galaxy_key
+
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 tools_update_repo:
   file.managed:

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -64,24 +64,6 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
-{% if '3.2-released' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
-tools_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - template: jinja
-
-{% elif 'released' in grains.get('version') | default('released', true) %}
-
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
@@ -92,19 +74,21 @@ tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_repo_needed
 
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
+
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -114,14 +98,6 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
@@ -129,14 +105,6 @@ tools_devel_repo:
     - template: jinja
 
 {% elif 'head' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -239,24 +207,6 @@ test_update_repo:
 
 {% endif %}
 
-{% if '3.2-released' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
-tools_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - template: jinja
-
-{% elif 'released' in grains.get('version') | default('released', true) %}
-
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -269,19 +219,21 @@ tools_update_repo:
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
 
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
+
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -291,14 +243,6 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
@@ -306,15 +250,6 @@ tools_devel_repo:
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
@@ -348,8 +283,6 @@ test_update_repo:
 {% endif %}
 {% endif %}
 
-{% if 'released' in grains.get('version') | default('released', true) %}
-
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Pool.repo
@@ -362,19 +295,13 @@ tools_update_repo:
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Update.repo
     - template: jinja
 
+{% if 'released' in grains.get('version') | default('released', true) %}
+
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -383,15 +310,6 @@ tools_devel_repo:
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
-
-tools_pool_repo:
-  file.touch:
-    - name: /tmp/no_tools_pool_repo_needed
-
-tools_update_repo:
-  file.touch:
-    - name: /tmp/no_tools_update_repo_needed
-
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-15-x86_64.repo

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -223,8 +223,8 @@ tools_update_repo:
 
 tools_devel_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
     - template: jinja
 
 {% elif 'released' in grains.get('version') | default('released', true) %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -64,6 +64,24 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
+
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
@@ -74,21 +92,19 @@ tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_repo_needed
 
-{% if '3.2-released' in grains.get('version') | default('', true) %}
-
-tools_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - template: jinja
-
-{% elif 'released' in grains.get('version') | default('released', true) %}
-
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -98,6 +114,14 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
@@ -105,6 +129,14 @@ tools_devel_repo:
     - template: jinja
 
 {% elif 'head' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -207,6 +239,24 @@ test_update_repo:
 
 {% endif %}
 
+{% if '3.2-released' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
+tools_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
+    - template: jinja
+
+{% elif 'released' in grains.get('version') | default('released', true) %}
+
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -219,21 +269,19 @@ tools_update_repo:
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
 
-{% if '3.2-released' in grains.get('version') | default('', true) %}
-
-tools_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-12-x86_64.repo
-    - template: jinja
-
-{% elif 'released' in grains.get('version') | default('released', true) %}
-
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -243,6 +291,14 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
@@ -250,6 +306,15 @@ tools_devel_repo:
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
@@ -283,6 +348,8 @@ test_update_repo:
 {% endif %}
 {% endif %}
 
+{% if 'released' in grains.get('version') | default('released', true) %}
+
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Pool.repo
@@ -295,13 +362,19 @@ tools_update_repo:
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-15-x86_64-Update.repo
     - template: jinja
 
-{% if 'released' in grains.get('version') | default('released', true) %}
-
 tools_devel_repo:
   file.touch:
     - name: /tmp/no_tools_devel_repo_needed
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
 
 tools_devel_repo:
   file.managed:
@@ -310,6 +383,15 @@ tools_devel_repo:
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
+
+tools_pool_repo:
+  file.touch:
+    - name: /tmp/no_tools_pool_repo_needed
+
+tools_update_repo:
+  file.touch:
+    - name: /tmp/no_tools_update_repo_needed
+
 tools_devel_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-15-x86_64.repo

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -36,9 +36,9 @@ tools_update_repo:
   file.touch:
     - name: /tmp/no_tools_update_repo_needed
 
-tools_devel_repo:
+tools_additional_repo:
   file.touch:
-    - name: /tmp/no_tools_devel_repo_needed
+    - name: /tmp/no_tools_additional_repo_needed
 {% endif %}
 
 
@@ -76,7 +76,7 @@ tools_update_repo:
 
 {% if '3.2-released' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -84,13 +84,13 @@ tools_devel_repo:
 
 {% elif 'released' in grains.get('version') | default('released', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.touch:
-    - name: /tmp/no_tools_devel_repo_needed
+    - name: /tmp/no_tools_additional_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-11-x86_64.repo
@@ -98,7 +98,7 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-11-x86_64.repo
@@ -106,7 +106,7 @@ tools_devel_repo:
 
 {% elif 'head' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-11-x86_64.repo
@@ -221,7 +221,7 @@ tools_update_repo:
 
 {% if '3.2-released' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
     - source: salt://default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -229,13 +229,13 @@ tools_devel_repo:
 
 {% elif 'released' in grains.get('version') | default('released', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.touch:
-    - name: /tmp/no_tools_devel_repo_needed
+    - name: /tmp/no_tools_additional_repo_needed
 
 {% elif '3.0-nightly' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.0_SLE-Manager-Tools-12-x86_64.repo
@@ -243,14 +243,14 @@ tools_devel_repo:
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-12-x86_64.repo
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-12-x86_64.repo
@@ -297,20 +297,20 @@ tools_update_repo:
 
 {% if 'released' in grains.get('version') | default('released', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.touch:
-    - name: /tmp/no_tools_devel_repo_needed
+    - name: /tmp/no_tools_additional_repo_needed
 
 {% elif 'nightly' in grains.get('version') | default('', true) %}
 
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-15-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_3.1_SLE-Manager-Tools-15-x86_64.repo
     - template: jinja
 
 {% elif ('head' in grains.get('version') | default('', true)) or ('test' in grains.get('version') | default('', true)) %}
-tools_devel_repo:
+tools_additional_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-15-x86_64.repo
     - source: salt://default/repos.d/Devel_Galaxy_Manager_Head_SLE-Manager-Tools-15-x86_64.repo
@@ -345,7 +345,7 @@ refresh_default_repos:
       - file: os_update_repo
       - file: tools_pool_repo
       - file: tools_update_repo
-      - file: tools_devel_repo
+      - file: tools_additional_repo
 {% endif %}
 
 {% if grains['os_family'] == 'RedHat' %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -78,8 +78,8 @@ tools_update_repo:
 
 tools_devel_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
-    - source: salt://default/repos.d/Devel_Galaxy_Manager_3.2_SLE-Manager-Tools-11-x86_64.repo
+    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+    - source: salt://default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
     - template: jinja
 
 {% elif 'released' in grains.get('version') | default('released', true) %}

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -91,6 +91,16 @@
   path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Updates/SUSE-Manager-Proxy/3.1/x86_64/update
   archs: [x86_64]
 
+# SUSE Manager 3.2
+- url: http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1
+  path: /srv/mirror/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1
+  archs: [x86_64]
+
+# SUSE Manager 3.2 Proxy
+- url: http://download.suse.de/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
+  path: /srv/mirror/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1
+  archs: [x86_64]
+
 # SLE 12 (GA and all SPs) Manager Tools
 - url: http://euklid.nue.suse.com/mirror/SuSE/build.suse.de/SUSE/Products/SLE-Manager-Tools/12/x86_64/product
   path: /srv/mirror/mirror/SuSE/build.suse.de/SUSE/Products/SLE-Manager-Tools/12/x86_64/product

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -225,6 +225,21 @@
   path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
   archs: [x86_64]
 
+# SLE 11 SP4 Manager Tools 3.2 devel
+- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+  archs: [x86_64]
+
+# SLE 12 (GA and all SPs) Manager Tools 3.2 devel
+- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
+  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
+  archs: [x86_64]
+
+# RES 7 Manager Tools 3.2 devel
+- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+  archs: [x86_64]
+
 # SUSE Manager Head devel
 - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3
   path: /srv/mirror/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -6,20 +6,18 @@ proxy-packages:
   pkg.latest:
     {% if 'head' in grains['version'] %}
     - fromrepo: Devel_Galaxy_Manager_Head
-    - name: patterns-suma_proxy
     {% elif '3.0-released' in grains['version'] %}
     - fromrepo: SUSE-Manager-Proxy-3.0-x86_64-Pool
-    - name: patterns-suma_proxy
     {% elif '3.0-nightly' in grains['version'] %}
     - fromrepo: Devel_Galaxy_Manager_3.0
-    - name: patterns-suma_proxy
     {% elif '3.1-released' in grains['version'] %}
     - fromrepo: SUSE-Manager-Proxy-3.1-x86_64-Pool
-    - name: patterns-suma_proxy
     {% elif '3.1-nightly' in grains['version'] %}
     - fromrepo: Devel_Galaxy_Manager_3.1
-    - name: patterns-suma_proxy
+    {% elif '3.2-released' in grains['version'] %}
+    - fromrepo: SUSE-Manager-Proxy-3.2-x86_64-Pool
     {% endif %}
+    - name: patterns-suma_proxy
     - require:
       - sls: suse_manager_proxy.repos
 

--- a/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.2-x86_64-Pool.repo
+++ b/salt/suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.2-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[SUSE-Manager-Proxy-3.2-x86_64-Pool]
+name=SUSE-Manager-Proxy-3.2-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Proxy-3.2-POOL-x86_64-Media1/
+priority=97

--- a/salt/suse_manager_proxy/repos.sls
+++ b/salt/suse_manager_proxy/repos.sls
@@ -37,6 +37,20 @@ suse_manager_proxy_update_repo:
       - sls: default
 {% endif %}
 
+{% if '3.2' in grains['version'] %}
+suse_manager_proxy_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-Proxy-3.2-x86_64-Pool.repo
+    - source: salt://suse_manager_proxy/repos.d/SUSE-Manager-Proxy-3.2-x86_64-Pool.repo
+    - template: jinja
+    - require:
+      - sls: default
+
+suse_manager_proxy_update_repo:
+  file.touch:
+    - name: /tmp/no_update_channel_needed
+{% endif %}
+
 {% if 'head' in grains['version'] %}
 suse_manager_proxy_pool_repo:
   file.managed:

--- a/salt/suse_manager_proxy/repos.sls
+++ b/salt/suse_manager_proxy/repos.sls
@@ -46,6 +46,8 @@ suse_manager_proxy_pool_repo:
     - require:
       - sls: default
 
+# HACK: the update repository for 3.2 does not exist yet
+#       don't forget to add it after GA
 suse_manager_proxy_update_repo:
   file.touch:
     - name: /tmp/no_update_channel_needed

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -27,6 +27,8 @@ suse_manager_packages:
     - fromrepo: SUSE-Manager-3.1-x86_64-Pool
     {% elif '3.1-nightly' in grains['version'] %}
     - fromrepo: Devel_Galaxy_Manager_3.1
+    {% elif '3.2-released' in grains['version'] %}
+    - fromrepo: SUSE-Manager-3.2-x86_64-Pool
     {% endif %}
     - name: patterns-suma_server
     - require:

--- a/salt/suse_manager_server/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
+++ b/salt/suse_manager_server/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
@@ -1,0 +1,6 @@
+[SUSE-Manager-3.2-x86_64-Pool]
+name=SUSE-Manager-3.2-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/SUSE:/SLE-12-SP3:/Update:/Products:/Manager32/images/repo/SUSE-Manager-Server-3.2-POOL-x86_64-Media1/
+priority=97

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -46,6 +46,8 @@ suse_manager_pool_repo:
     - require:
       - sls: default
 
+# HACK: the update repository for 3.2 does not exist yet
+#       don't forget to add it after GA
 suse_manager_update_repo:
   file.touch:
     - name: /tmp/no_update_channel_needed

--- a/salt/suse_manager_server/repos.sls
+++ b/salt/suse_manager_server/repos.sls
@@ -37,6 +37,20 @@ suse_manager_update_repo:
       - sls: default
 {% endif %}
 
+{% if '3.2' in grains['version'] %}
+suse_manager_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
+    - source: salt://suse_manager_server/repos.d/SUSE-Manager-3.2-x86_64-Pool.repo
+    - template: jinja
+    - require:
+      - sls: default
+
+suse_manager_update_repo:
+  file.touch:
+    - name: /tmp/no_update_channel_needed
+{% endif %}
+
 {% if 'head' in grains['version'] %}
 suse_manager_pool_repo:
   file.managed:


### PR DESCRIPTION
This PR adds support for `3.2-released`, currently defined as latest beta.

Notes:
* the server and proxy pool repository URLs are hardcoded for SLE 12 SP3, but now we also support openSUSE 42.3. I did not find a beta repository for 42.3 though;
* I had to add the development tools repository, otherwise it would not install fine (apache2 was not starting).
* I did not add the other development repositories.

It works with this setup, but please check whether this is correct. Honestly, I'm a bit lost in this repositories jungle.
