### PR TITLE
log salt-ssh client log outside of the thin dir

### DIFF
--- a/salt/suse_manager_server/master-custom.conf
+++ b/salt/suse_manager_server/master-custom.conf
@@ -1,0 +1,4 @@
+auto_accept: True
+ssh_minion_opts:
+    log_file: ../../../../../var/log/salt-ssh.log
+    log_level: debug

--- a/salt/suse_manager_server/salt_master.sls
+++ b/salt/suse_manager_server/salt_master.sls
@@ -6,8 +6,7 @@ include:
 custom_salt_master_configuration:
   file.managed:
     - name: /etc/salt/master.d/custom.conf
-    - contents: |
-        auto_accept: True
+    - source: salt://suse_manager_server/master-custom.conf
     - require:
         - sls: suse_manager_server
 


### PR DESCRIPTION
while using --wipe the logs went away.
Configuring logfile outside of the thin keep it visible and can be used for debugging.
Also run in debug mode.