### PR TITLE
Additional repositories on CentOS don't use zypper

### DIFF
--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -402,7 +402,11 @@ tools_update_repo:
 
 refresh_additional_repos:
   cmd.run:
+{% if grains['os_family'] == 'RedHat' %}
+    - name: echo "(repository refresh not needed with yum)"
+{% else %}
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
+{% endif %}
     - require:
       {% for label, url in grains['additional_repos'].items() %}
       - pkgrepo: {{ label }}_repo


### PR DESCRIPTION
This PR removes the call of `zypper refresh` to refresh additional repositories in case we are using CentOS.

Since ` yum` refreshes the packages lists at each command, we don't do anything instead.