### PR TITLE
Add BuildRepo and install dummy packages also on RedHat systems

### DIFF
--- a/salt/client/testsuite.sls
+++ b/salt/client/testsuite.sls
@@ -44,6 +44,23 @@ suse_client_cucumber_requisites:
     - require:
       - cmd: refresh_client_repos
 
+{% elif grains['os_family'] == 'RedHat' %}
+
+testsuite_build_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/Devel_Galaxy_BuildRepo.repo
+    - source: salt://client/repos.d/Devel_Galaxy_BuildRepo.repo
+    - template: jinja
+
+res_client_cucumber_requisites:
+  pkg.installed:
+    - pkgs:
+      - andromeda-dummy
+      - milkyway-dummy
+      - virgo-dummy
+    - require:
+      - file: testsuite_build_repo
+
 {% endif %}
 
 {% endif %}

--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -84,7 +84,25 @@ update_ca_truststore:
       - file: suse_certificate
     - require:
       - pkg: suse_minion_cucumber_requisites
+
 {% endif %}
+
+{% elif grains['os_family'] == 'RedHat' %}
+
+testsuite_build_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/Devel_Galaxy_BuildRepo.repo
+    - source: salt://client/repos.d/Devel_Galaxy_BuildRepo.repo
+    - template: jinja
+
+res_client_cucumber_requisites:
+  pkg.installed:
+    - pkgs:
+      - andromeda-dummy
+      - milkyway-dummy
+      - virgo-dummy
+    - require:
+      - file: testsuite_build_repo
 
 {% endif %}
 


### PR DESCRIPTION
In order to test patch installation on CentOS we need the BuildRepo and some packages installed
we can update using the testsuite repo.