### PR TITLE
add sle-es7.4 packer img

### DIFF
--- a/packer/http/ks_sles-es7.cfg
+++ b/packer/http/ks_sles-es7.cfg
@@ -1,0 +1,235 @@
+# See documentation:
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+
+# We want to "install"
+install
+
+cdrom
+
+# Fail when installation interactively prompts for anything
+cmdline
+
+# Set the language
+lang en_US.UTF-8
+
+keyboard us
+network --bootproto=dhcp
+
+# Sets the root password because we do not want any prompt during installation (password)
+rootpw linux
+
+firewall --disabled
+authconfig --enableshadow --passalgo=sha512 --enablefingerprint
+selinux --disabled
+timezone --utc Europe/Berlin
+bootloader --location=mbr
+
+# repo to install salt-minion
+repo --name=sumatools-final --install --baseurl=http://nu.novell.com/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/
+
+skipx
+
+autopart --type=plain
+zerombr
+clearpart --all --initlabel
+
+reboot
+
+# install only base packages and openssh
+%packages --nobase --excludedocs --instLangs=en
+@Core
+-aic94xx-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-linux-firmware
+-b43-fwcutter
+-b43-openfwwf
+-perl
+-perl-Module-Pluggable
+-perl-Pod-Escapes
+-perl-Pod-Simple
+-perl-libs
+-perl-version
+-vim-enhanced
+-abrt
+-abrt-addon-ccpp
+-abrt-addon-kerneloops
+-abrt-addon-python
+-abrt-cli
+-abrt-libs
+-abrt-tui
+-libreport
+-libreport-cli
+-libreport-compat
+-libreport-plugin-kerneloops
+-libreport-plugin-logger
+-libreport-plugin-mailx
+-libreport-plugin-reportuploader
+-libreport-plugin-rhtsupport
+-libreport-python
+-cups-libs
+-fprintd
+-fprintd-pam
+-gtk2
+-libfprint
+-mysql-libs
+-cronie
+-cronie-anacron
+-crontabs
+-postfix
+-sysstat
+-alsa-lib
+-alsa-utils
+-man
+-man-pages
+-man-pages-overrides
+-yum-utils
+-system-config-firewall-base
+-system-config-firewall-tui
+-system-config-network-tui
+-systemtap-runtime
+-at
+-atk
+-bc
+-bind-libs
+-bind-utils
+-biosdevname
+-blktrace
+-busybox
+-cairo
+-centos-indexhtml
+-ConsoleKit
+-ConsoleKit-libs
+-cpuspeed
+-crda
+-cyrus-sasl-plain
+-dbus
+-dbus-python
+-desktop-file-utils
+-dmidecode
+-dmraid
+-dmraid-events
+-dosfstools
+-ed
+-eggdbus
+-eject
+-elfutils-libs
+-fontconfig
+-freetype
+-gnutls
+-hal
+-hal-info
+-hal-libs
+-hdparm
+-hicolor-icon-theme
+-hunspell
+-hunspell-en
+-irqbalance
+-iw
+-jasper-libs
+-kexec-tools
+-ledmon
+-libjpeg-turbo
+-libnl
+-libpcap
+-libpng
+-libtasn1
+-libthai
+-libtiff
+-libusb1
+-libX11
+-libX11-common
+-libXau
+-libxcb
+-libXcomposite
+-libXcursor
+-libXdamage
+-libXext
+-libXfixes
+-libXft
+-libXi
+-libXinerama
+-libxml2-python
+-libXrandr
+-libXrender
+-lsof
+-mailx
+-microcode_ctl
+-mlocate
+-mtr
+-nano
+-ntp
+-ntpdate
+-ntsysv
+-numactl
+-pam_passwdqc
+-pango
+-parted
+-pciutils
+-pcmciautils
+-pinfo
+-pixman
+-pkgconfig
+-pm-utils
+-polkit
+-prelink
+-psacct
+-python-ethtool
+-python-iwlib
+-quota
+-rdate
+-readahead
+-rfkill
+-rng-tools
+-rsync
+-scl-utils
+-setserial
+-setuptool
+-sg3_utils-libs
+-sgpio
+-smartmontools
+-sos
+-strace
+-tcpdump
+-tcp_wrappers
+-tcsh
+-time
+-tmpwatch
+-traceroute
+-unzip
+-usbutils
+-usermode
+-vconfig
+-wget
+-wireless-tools
+-words
+-xdg-utils
+-xz
+-xz-lzma-compat
+-yum-plugin-security
+-yum-utils
+-zip
+
+openssh-clients
+avahi
+qemu-guest-agent
+salt-minion
+
+%end
+
+%post --log=/root/post.log --nochroot
+
+# rebuild the initramfs
+# http://lists.openstack.org/pipermail/openstack/2015-January/011245.html
+# http://lists.openstack.org/pipermail/openstack/2014-August/008802.html
+dracut --force
+
+%end

--- a/packer/scripts/base-es.sh
+++ b/packer/scripts/base-es.sh
@@ -1,0 +1,10 @@
+rpm --import http://nu.novell.com/repo/$RCE/RES7-SUSE-Manager-Tools/x86_64/repodata/repomd.xml.key
+
+yum -y update
+yum -y install wget curl openssh-server
+
+# Install root certificates
+yum -y install ca-certificates
+
+# Make ssh faster by not waiting on DNS
+echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/packer/sles-es7.json
+++ b/packer/sles-es7.json
@@ -15,6 +15,8 @@
       "name": "sles-es7",
       "type": "qemu",
       "iso_url": "http://schnell.nue.suse.com/RHEL/SLES-ES/SLES-ES-7.4-x86_64-DVD.iso",
+      "iso_checksum": "0d728f273de09974da92ccd42cb7d60201a3d5e637966fe4b90863065bee84db",
+      "iso_checksum_type": "sha256",
       "ssh_wait_timeout": "30s",
       "shutdown_command": "shutdown -P now",
       "disk_size": 204800,

--- a/packer/sles-es7.json
+++ b/packer/sles-es7.json
@@ -1,0 +1,45 @@
+{
+  "provisioners": [{
+    "type": "shell",
+    "scripts": [
+      "scripts/base-es.sh",
+      "scripts/cleanup.sh"
+    ],
+    "override": {
+      "sles-es7": {
+        "execute_command": "sh '{{.Path}}'"
+      }
+    }
+  }],
+  "builders": [{
+      "name": "sles-es7",
+      "type": "qemu",
+      "iso_url": "http://schnell.nue.suse.com/RHEL/SLES-ES/SLES-ES-7.4-x86_64-DVD.iso",
+      "ssh_wait_timeout": "30s",
+      "shutdown_command": "shutdown -P now",
+      "disk_size": 204800,
+      "iso_checksum_type": "none",
+      "format": "qcow2",
+      "qemuargs": [
+        [ "-m", "1024M" ],
+        ["-machine", "type=pc,accel=kvm"],
+        ["-device", "virtio-net-pci,netdev=user.0"]
+      ],
+      "headless": true,
+      "accelerator": "kvm",
+      "http_directory": "http",
+      "http_port_min": 10082,
+      "http_port_max": 10089,
+      "ssh_host_port_min": 2222,
+      "ssh_host_port_max": 2229,
+      "ssh_username": "root",
+      "ssh_password": "linux",
+      "ssh_port": 22,
+      "ssh_wait_timeout": "90m",
+      "vm_name": "sles-es7",
+      "disk_interface": "virtio",
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_sles-es7.cfg<enter><wait>"
+      ]
+    }]
+}


### PR DESCRIPTION
## what does this pr?

we want to use sles-expanded support instead of centos7 for CI tests. 

This pr is the first milestone for achiving this.

We will have an image that works already with sumaform and avahi setup.

Where we will put this image? Schnell.suse.de or elsewehere?

i already tested the image with sumaform and everything works (avahi, ssh, salt).

I didn't test to swtich centos7 to sles-es but is out of scope for this

### need discussion:

where to place the img
- schnell.suse.de
- or like centos7 location

### how can you test this image:

download the image from here (tomorrow)
```m226.mgr.suse.de:/home/jenkins/workspace/sles-es7``` now i have 20% updted                                                                                                         

