### PR TITLE
3.2-released will point to RC1 instead of beta3

### DIFF
--- a/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-RES-7-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/RES7/x86_64
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-11-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-12-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE12/x86_64/update
 priority=98

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -226,18 +226,18 @@
   archs: [x86_64]
 
 # SLE 11 SP4 Manager Tools 3.2 devel
-- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
-  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+- url: http://beta.suse.com/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64
+  path: /srv/mirror/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64
   archs: [x86_64]
 
 # SLE 12 (GA and all SPs) Manager Tools 3.2 devel
-- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
-  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
+- url: http://beta.suse.com/private/SUSE-Manager-beta/RC1/SLE12/x86_64/update
+  path: /srv/mirror/private/SUSE-Manager-beta/RC1/SLE12/x86_64/update
   archs: [x86_64]
 
 # RES 7 Manager Tools 3.2 devel
-- url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/RES7/x86_64
-  path: /srv/mirror/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+- url: http://beta.suse.com/private/SUSE-Manager-beta/RC1/RES7/x86_64
+  path: /srv/mirror/private/SUSE-Manager-beta/RC1/RES7/x86_64
   archs: [x86_64]
 
 # SUSE Manager Head devel


### PR DESCRIPTION
This PR changes the meaning of `3.2-released` version, from "Beta 3" to RC1.

Note: RC1 is not out yet - the RC1 developmenet tools repos are a kind of "preview", i.e. they currently contain Beta3 + some fixes.
