### PR TITLE
[WIP] Adding new role: SSH minion

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -315,7 +315,7 @@ The performance testsuite relies on the `evil-minions` load generator in order t
 
 ## Cucumber testsuite
 
-It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the `main.tf.libvirt-testsuite.example` file. This will create a test server, client and minion instances, plus a coordination node called a `controller` which runs the testsuite.
+It is possible to run [the Cucumber testsuite for SUSE Manager](https://github.com/SUSE/spacewalk-testsuite-base/) by using the `main.tf.libvirt-testsuite.example` file. This will create a test server, client, SSH minion and minion instances, plus a coordination node called a `controller` which runs the testsuite.
 
 The proxy, the SSH minion, and the CentOS minion are optional. The server, traditional client and normal minion are not.
 

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -73,7 +73,7 @@ module "min-sles12sp3" {
 
 # optional
 module "minssh-sles12sp3" {
-  source = "./modules/libvirt/host"
+  source = "./modules/libvirt/ssh_minion"
   base_configuration = "${module.base.configuration}"
   name = "minssh-sles12sp3"
   image = "sles12sp3"

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -86,7 +86,7 @@ module "min-sles12sp3" {
 
 # optional
 module "minssh-sles12sp3" {
-  source = "./modules/openstack/host"
+  source = "./modules/openstack/ssh_minion"
   base_configuration = "${module.base.configuration}"
   name = "minssh-sles12sp3"
   image = "sles12sp3"

--- a/modules/libvirt/ssh_minion/main.tf
+++ b/modules/libvirt/ssh_minion/main.tf
@@ -1,0 +1,34 @@
+module "ssh_minion" {
+  source = "../host"
+
+  base_configuration = "${var.base_configuration}"
+  name = "${var.name}"
+  count = "${var.count}"
+  use_released_updates = "${var.use_released_updates}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
+  gpg_keys = "${var.gpg_keys}"
+  ssh_key_path = "${var.ssh_key_path}"
+  grains = <<EOF
+
+version: ${var.version}
+mirror: ${var.base_configuration["mirror"]}
+role: ssh_minion
+testsuite: ${var.base_configuration["testsuite"]}
+evil_minions_dump: ${var.evil_minions_dump}
+apparmor: ${var.apparmor}
+
+EOF
+
+  // Provider-specific variables
+  image = "${var.image}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
+}
+
+output "configuration" {
+  value = "${module.ssh_minion.configuration}"
+}

--- a/modules/libvirt/ssh_minion/variables.tf
+++ b/modules/libvirt/ssh_minion/variables.tf
@@ -1,0 +1,82 @@
+variable "base_configuration" {
+  description = "use ${module.base.configuration}, see the main.tf example file"
+  type = "map"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type = "string"
+}
+
+variable "evil_minions_dump" {
+  description = "whether this minion should create a dump file to be used for evil-minions"
+  default = false
+}
+
+variable "use_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default = false
+}
+
+variable "use_unreleased_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
+  default = false
+}
+
+variable "apparmor" {
+  description = "whether AppArmor access control should be installed"
+  default = false
+}
+
+variable "additional_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages which should be installed"
+  default = []
+}
+
+variable "count"  {
+  description = "number of hosts like this one"
+  default = 1
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15rc4, centos7"
+  type = "string"
+}
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 512
+}
+
+variable "vcpu" {
+  description = "Number of virtual CPUs"
+  default = 1
+}
+
+variable "running" {
+  description = "Whether this host should be turned on or off"
+  default = true
+}
+
+variable "mac" {
+  description = "a MAC address in the form AA:BB:CC:11:22:22"
+  default = ""
+}

--- a/modules/openstack/ssh_minion/main.tf
+++ b/modules/openstack/ssh_minion/main.tf
@@ -1,0 +1,32 @@
+module "ssh_minion" {
+  source = "../host"
+
+  base_configuration = "${var.base_configuration}"
+  name = "${var.name}"
+  count = "${var.count}"
+  use_released_updates = "${var.use_released_updates}"
+  use_unreleased_updates = "${var.use_unreleased_updates}"
+  additional_repos = "${var.additional_repos}"
+  additional_packages = "${var.additional_packages}"
+  gpg_keys = "${var.gpg_keys}"
+  ssh_key_path = "${var.ssh_key_path}"
+  grains = <<EOF
+
+version: ${var.version}
+mirror: ${var.base_configuration["mirror"]}
+role: ssh_minion
+testsuite: ${var.base_configuration["testsuite"]}
+evil_minions_dump: ${var.evil_minions_dump}
+apparmor: ${var.apparmor}
+
+EOF
+
+  // Provider-specific variables
+  image = "${var.image}"
+  flavor = "${var.flavor}"
+  floating_ips = "${var.floating_ips}"
+}
+
+output "configuration" {
+  value = "${module.ssh_minion.configuration}"
+}

--- a/modules/openstack/ssh_minion/variables.tf
+++ b/modules/openstack/ssh_minion/variables.tf
@@ -1,0 +1,72 @@
+variable "base_configuration" {
+  description = "use ${module.base.configuration}, see the main.tf example file"
+  type = "map"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type = "string"
+}
+
+variable "evil_minions_dump" {
+  description = "whether this minion should create a dump file to be used for evil-minions"
+  default = false
+}
+
+variable "use_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default = false
+}
+
+variable "use_unreleased_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
+  default = false
+}
+
+variable "apparmor" {
+  description = "whether AppArmor access control should be installed"
+  default = false
+}
+
+variable "additional_repos" {
+  description = "extra repositories used for installation {label = url}"
+  default = {}
+}
+
+variable "additional_packages" {
+  description = "extra packages which should be installed"
+  default = []
+}
+
+variable "count"  {
+  description = "number of hosts like this one"
+  default = 1
+}
+
+variable "ssh_key_path" {
+  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+  default = "/dev/null"
+  # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
+}
+
+variable "gpg_keys" {
+  description = "salt/ relative paths of gpg keys that you want to add to your VMs, see README_ADVANCED.md"
+  default = []
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15rc4, centos7"
+  type = "string"
+}
+
+variable "flavor" {
+  description = "OpenStack flavor"
+  default = "m1.small"
+}
+
+variable "floating_ips" {
+  description = "List of floating IP IDs to associate"
+  default = []
+}


### PR DESCRIPTION
"SSH minion" clients were previously managed with the generic "host" module. Since we want to add test repositories when we are using them from the testsuite, this is not enough anymore.

This PR adds the following:
* a new `ssh_minion` terraform module for both `libvirt`and `openstack`providers
* a new `role:ssh_minion` Salt grain
* a new `ssh_minion/` subdirectory of `salt/` directory, with a `testsuite.sls` file in it
