### PR TITLE
Appending "update/" to path to SLE11SP4 repo

### DIFF
--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-11-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64/update
 priority=98


### PR DESCRIPTION
According to Michael's email, the path to SLE11SP4 has changed - for RES 7 I'm not sure.