### PR TITLE
Change the default memory in controller. Fixes #347

### DIFF
--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -82,7 +82,7 @@ variable "ssh_key_path" {
 
 variable "memory" {
   description = "RAM memory in MiB"
-  default = 1024
+  default = 2048
 }
 
 variable "running" {


### PR DESCRIPTION
If you agree this changes one line to change the memory from 1024 to 2048 so we can remove it from the jobs specific conf and leave the default when this gets merged. Fixes #347 