### PR TITLE
add missing 3.2 main repository to minima

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -102,6 +102,10 @@ http:
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.1/SLE_12_SP2
     archs: [x86_64]
 
+  # SUSE Manager 3.2 devel
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2/SLE_12_SP3
+    archs: [x86_64]
+
   # SLE 11 SP4 Manager Tools 3.2 devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/3.2:/SLE11-SUSE-Manager-Tools/images/repo/SLE-11-SP4-CLIENT-TOOLS-ia64-ppc64-s390x-x86_64-Media1/suse
     archs: [x86_64]


### PR DESCRIPTION
The new 3.2 main repo is missing in the minimal configuration