### PR TITLE
Switch to SLE15, Centos URL fix and switch of default for the EC2 cloud 

### DIFF
--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -21,9 +21,9 @@ module "base" {
   // name_prefix = ""
   // timezone = "Europe/Berlin"
 
-  // uncomment the following if you are targeting the SUSE internal "ECP" Cloud
-  // mirror = "mirror.tf.local"
-  // use_shared_resources = true
+  // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud 
+  mirror = "mirror.tf.local"
+  use_shared_resources = true
 }
 
 module "srv" {

--- a/main.tf.openstack.example
+++ b/main.tf.openstack.example
@@ -21,9 +21,9 @@ module "base" {
   // name_prefix = ""
   // timezone = "Europe/Berlin"
 
-  // uncomment the following if you are targeting the SUSE internal "ECP" Cloud
-  // mirror = "mirror.tf.local"
-  // use_shared_resources = true
+  // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud
+  mirror = "mirror.tf.local"
+  use_shared_resources = true
 }
 
 module "suma3pg" {

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -62,14 +62,14 @@ variable "bridge" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default = ["centos7",  "opensuse423",  "sles11sp3",  "sles11sp4",  "sles12",   "sles12sp1",  "sles12sp2", "sles12sp3", "sles15beta4"]
+  default = ["centos7",  "opensuse423",  "sles11sp3",  "sles11sp4",  "sles12",   "sles12sp1",  "sles12sp2", "sles12sp3", "sles15"]
   type = "list"
 }
 
 variable "image_locations" {
   description = "list of locations to download images, override to add custom ones"
   default = {
-    centos7 = "http://w3.nue.suse.com/~smoioli/sumaform-images/centos7_v3.qcow2"
+    centos7 = "http://w3.nue.suse.com/~smoioli/sumaform-images/centos7.qcow2"
     opensuse423 = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse423.x86_64.qcow2"
     sles11sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp3.x86_64.qcow2"
     sles11sp4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
@@ -77,7 +77,7 @@ variable "image_locations" {
     sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp1.x86_64.qcow2"
     sles12sp2 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp2.x86_64.qcow2"
     sles12sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles12sp3.x86_64.qcow2"
-    sles15beta4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15beta4.x86_64.qcow2"
+    sles15 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
   }
   type = "map"
 }

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -62,7 +62,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15"
   type = "string"
 }
 

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -42,7 +42,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
+  description = "One of: opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15, centos7"
   type = "string"
 }
 

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -67,7 +67,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15, centos7"
   type = "string"
 }
 

--- a/modules/openstack/base/variables.tf
+++ b/modules/openstack/base/variables.tf
@@ -47,7 +47,7 @@ variable "use_shared_resources" {
 
 variable "images" {
   description = "list of images to be uploaded to Glance, leave default for all"
-  default = ["centos7", "opensuse423",  "sles12sp3",  "sles12sp2",  "sles12sp1",   "sles12",  "sles11sp4", "sles11sp3", "sles15beta4"]
+  default = ["centos7", "opensuse423",  "sles12sp3",  "sles12sp2",  "sles12sp1",   "sles12",  "sles11sp4", "sles11sp3", "sles15"]
   type = "list"
 }
 
@@ -62,7 +62,7 @@ variable "image_locations" {
     sles12sp1 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles12sp1.x86_64.qcow2"
     sles12sp2 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles12sp2.x86_64.qcow2"
     sles12sp3 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles12sp3.x86_64.qcow2"
-    sles15beta4 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles15beta4.x86_64.qcow2"
+    sles15 = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles15.x86_64.qcow2"
   }
   type = "map"
 }

--- a/modules/openstack/client/variables.tf
+++ b/modules/openstack/client/variables.tf
@@ -62,7 +62,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15"
   type = "string"
 }
 

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -42,7 +42,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4"
+  description = "One of: opensuse423, sles11sp3, sles11sp4, sles12, sles12sp1, sles15"
   type = "string"
 }
 

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -67,7 +67,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15beta4, centos7"
+  description = "One of: sles11sp3, sles11sp4, sles12, sles12sp1, sles15, centos7"
   type = "string"
 }
 


### PR DESCRIPTION
* Switching the image URLs from SLE15beta4 to SLE15. Not sure if anything else is needed.
* Image URL for Centos7 seems to have changed. There is no longer a centos7_v3…
* Seems that I've missed to create an PR for this. I think "Making SUSE ECP Cloud the default" would make sense for our target user group.