### PR TITLE
3.2-released will point to GMC instead of RC1

### DIFF
--- a/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-RES-7-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/RES7/x86_64
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC/RES7/x86_64
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-11-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE11SP4/x86_64/update
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC/SLE11SP4/x86_64/update
 priority=98

--- a/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/default/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -2,5 +2,5 @@
 name=SLE-Manager-Tools-SLE-12-Beta-x86_64
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/RC1/SLE12/x86_64/update
+baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC/SLE12/x86_64/update
 priority=98

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -123,15 +123,15 @@ http:
     archs: [x86_64]
 
   # SLE 11 SP4 Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE11SP4/x86_64
+  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC/SLE11SP4/x86_64/update
     archs: [x86_64]
 
   # SLE 12 (GA and all SPs) Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/SLE12/x86_64/update
+  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC/SLE12/x86_64/update
     archs: [x86_64]
 
   # RES 7 Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/Beta3/RES7/x86_64
+  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC/RES7/x86_64
     archs: [x86_64]
 
   # SUSE Manager Head devel


### PR DESCRIPTION
RC1 -> GMC in repos URLs