### PR TITLE
Bugfix: in case of sle11 systems require is empty.

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -44,10 +44,10 @@ containers_updates_repo:
 refresh_minion_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
-    - require:
       {% if '12' in grains['osrelease'] or '15' in grains['osrelease'] %}
-      - file: containers_pool_repo
-      - file: containers_updates_repo
+      - require:
+        - file: containers_pool_repo
+        - file: containers_updates_repo
       {% endif %}
 
 suse_minion_cucumber_requisites:


### PR DESCRIPTION
Fix this jinja2 bug.

I didn't tested it but should work.

In case of sles11sp4 the require is empty which cause a jinja2 error breaking sumaform
https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-cucumber-sle11sp4/140/consoleFull