### PR TITLE
exporter packages include services

### DIFF
--- a/salt/grafana/init.sls
+++ b/salt/grafana/init.sls
@@ -19,6 +19,7 @@ prometheus_configuration:
               - targets: ['{{grains["server"]}}:9100'] # node_exporter
               - targets: ['{{grains["server"]}}:9187'] # postgres_exporter
               - targets: ['{{grains["server"]}}:5556'] # jmx_exporter
+              - targets: ['{{grains["server"]}}:5557'] # jmx_exporter taskomatic
               {% if grains["locust"] %}
               - targets: ['{{grains["locust"]}}:9500'] # locust_exporter
               {% endif %}

--- a/salt/suse_manager_server/postgres-exporter
+++ b/salt/suse_manager_server/postgres-exporter
@@ -1,0 +1,19 @@
+## Path:           Applications/PostgreSQLExporter
+## Description:    Prometheus exporter for PostgreSQL
+## Type:           string()
+## Default:        "postgresql://user:passwd@localhost:5432/database?sslmode=disable"
+## ServiceRestart: postgres-exporter
+#
+# Connection URL to postgresql instance
+#
+DATA_SOURCE_NAME="postgresql://spacewalk:spacewalk@localhost:5432/susemanager?sslmode=disable"
+
+## Path:           Applications/PostgreSQLExporter
+## Description:    Prometheus exporter for PostgreSQL
+## Type:           string()
+## Default:        ""
+## ServiceRestart: postgres-exporter
+#
+# Extra options for postgres-exporter
+#
+POSTGRES_EXPORTER_PARAMS="-extend.query-path /etc/postgres_exporter/postgres_exporter_queries.yaml"

--- a/salt/suse_manager_server/prometheus.sls
+++ b/salt/suse_manager_server/prometheus.sls
@@ -101,4 +101,33 @@ jmx_exporter_service:
     - require:
       - pkg: jmx_exporter
 
+jmx_exporter_taskomatic_config:
+  file.managed:
+    - name: /etc/jmx_exporter/taskomatic/environment
+    - makedirs: True
+    - contents: |
+        PORT="5557"
+        EXP_PARAMS=""
+  file.managed:
+    - name: /etc/jmx_exporter/taskomatic/jmx_exporter.yml
+    - makedirs: True
+    - contents: |
+        hostPort: localhost:3334
+        username:
+        password:
+        whitelistObjectNames:
+          - java.lang:type=Threading,*
+          - java.lang:type=Memory,*
+          - Catalina:type=ThreadPool,name=*
+        rules:
+        - pattern: ".*"
+
+jmx_exporter_taskomatic_service:
+  service.running:
+    - name: jmx-exporter@taskomatic
+    - enable: True
+    - require:
+      - pkg: jmx_exporter
+      - file: jmx_exporter_taskomatic_config
+
 {% endif %}

--- a/salt/suse_manager_server/prometheus.sls
+++ b/salt/suse_manager_server/prometheus.sls
@@ -94,20 +94,22 @@ jmx_exporter:
     - require:
       - sls: repos
 
-jmx_exporter_service:
+jmx_exporter_tomcat_service:
   service.running:
     - name: jmx-exporter@tomcat
     - enable: True
     - require:
       - pkg: jmx_exporter
 
-jmx_exporter_taskomatic_config:
+jmx_exporter_taskomatic_systemd_config:
   file.managed:
     - name: /etc/jmx_exporter/taskomatic/environment
     - makedirs: True
     - contents: |
         PORT="5557"
         EXP_PARAMS=""
+
+jmx_exporter_taskomatic_yaml_config:
   file.managed:
     - name: /etc/jmx_exporter/taskomatic/jmx_exporter.yml
     - makedirs: True
@@ -128,6 +130,7 @@ jmx_exporter_taskomatic_service:
     - enable: True
     - require:
       - pkg: jmx_exporter
-      - file: jmx_exporter_taskomatic_config
+      - file: jmx_exporter_taskomatic_systemd_config
+      - file: jmx_exporter_taskomatic_yaml_config
 
 {% endif %}


### PR DESCRIPTION
The exporter packages now include the systemd service files. 
This requires changes in the configuration.

In addition I have added a jmx_exporter for taskomatic as jmx_exporter is now a template service which can run multiple instances on a system with different configurations.