### PR TITLE
Fix check for grain with right value for role suse_manager_server

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -175,7 +175,7 @@ test_update_repo:
 
 {% endif %}
 
-{% if 'suse_manager' not in grains.get('role') %}
+{% if 'suse_manager_server' not in grains.get('role') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -214,7 +214,7 @@ tools_additional_repo:
 
 {% endif %}
 
-{% endif %} {# 'suse_manager' not in grains.get('role') #}
+{% endif %} {# 'suse_manager_server' not in grains.get('role') #}
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
@@ -239,7 +239,7 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
-{% if 'suse_manager' not in grains.get('role') %}
+{% if 'suse_manager_server' not in grains.get('role') %}
 
 tools_pool_repo:
   file.managed:
@@ -269,7 +269,7 @@ tools_additional_repo:
     - template: jinja
 
 {% endif %}
-{% endif %} {# 'suse_manager' not in grains.get('role') #}
+{% endif %} {# 'suse_manager_server' not in grains.get('role') #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -175,7 +175,7 @@ test_update_repo:
 
 {% endif %}
 
-{% if 'suse_manager_server' not in grains.get('role') %}
+{% if 'suse_manager_server' != grains.get('role') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -214,7 +214,7 @@ tools_additional_repo:
 
 {% endif %}
 
-{% endif %} {# 'suse_manager_server' not in grains.get('role') #}
+{% endif %} {# 'suse_manager_server' != grains.get('role') #}
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
@@ -239,7 +239,7 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
-{% if 'suse_manager_server' not in grains.get('role') %}
+{% if 'suse_manager_server' != grains.get('role') %}
 
 tools_pool_repo:
   file.managed:
@@ -269,7 +269,7 @@ tools_additional_repo:
     - template: jinja
 
 {% endif %}
-{% endif %} {# 'suse_manager_server' not in grains.get('role') #}
+{% endif %} {# 'suse_manager_server' != grains.get('role') #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
 

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -22,6 +22,12 @@ suse_manager_packages:
       - sls: repos
       - sls: suse_manager_server.firewall
 
+java_ibm:
+  pkg.installed:
+    - name: java-1_8_0-ibm
+    - require:
+      - sls: repos
+
 environment_setup_script:
   file.managed:
     - name: /root/setup_env.sh


### PR DESCRIPTION
The check for grain role is not matching:
```
https://github.com/moio/sumaform/blob/master/salt/repos/default.sls:

{% if 'suse_manager' not in grains.get('role') %}
```
while in:
```
https://github.com/moio/sumaform/blob/master/salt/top.sls:

  'role:suse_manager_server':
    - match: grain
    - suse_manager_server

```

This should fix that.