### PR TITLE
Fix wrong comparison since grains['role'] is not a list

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -175,7 +175,7 @@ test_update_repo:
 
 {% endif %}
 
-{% if grains.get('role') != 'suse_manager' %}
+{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -214,7 +214,7 @@ tools_additional_repo:
 
 {% endif %}
 
-{% endif %} {# grains.get('role') != 'suse_manager' #}
+{% endif %} {# not grains.get('role') or not grains.get('role').startswith('suse_manager') #}
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
@@ -239,7 +239,7 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
-{% if grains.get('role') != 'suse_manager' %}
+{% if not grains.get('role') or not grains.get('role').startswith('suse_manager') %}
 
 tools_pool_repo:
   file.managed:
@@ -269,7 +269,7 @@ tools_additional_repo:
     - template: jinja
 
 {% endif %}
-{% endif %} {# grains.get('role') != 'suse_manager' #}
+{% endif %} {# not grains.get('role') or not grains.get('role').startswith('suse_manager') #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -175,7 +175,7 @@ test_update_repo:
 
 {% endif %}
 
-{% if 'suse_manager' not in grains.get('role') %}
+{% if grains.get('role') != 'suse_manager' %}
 tools_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
@@ -214,7 +214,7 @@ tools_additional_repo:
 
 {% endif %}
 
-{% endif %} {# 'suse_manager' not in grains.get('role') #}
+{% endif %} {# grains.get('role') != 'suse_manager' #}
 {% endif %} {# '12' in grains['osrelease'] #}
 
 
@@ -239,7 +239,7 @@ test_update_repo:
     - template: jinja
 {% endif %}
 
-{% if 'suse_manager' not in grains.get('role') %}
+{% if grains.get('role') != 'suse_manager' %}
 
 tools_pool_repo:
   file.managed:
@@ -269,7 +269,7 @@ tools_additional_repo:
     - template: jinja
 
 {% endif %}
-{% endif %} {# 'suse_manager' not in grains.get('role') #}
+{% endif %} {# grains.get('role') != 'suse_manager' #}
 {% endif %} {# '15' in grains['osrelease'] #}
 
 


### PR DESCRIPTION
This PR fixes an issue while deploying the `minssh-sles12sp3` minion on the testsuite. There is a jinja2 error while rendering the template because a bad comparison that wrongly assumes `grains['role']` is a list (the `not in` operator expects an interable object):

```
{% if 'suse_manager' not in grains.get('role') %}    <======================                                                                                                 
tools_pool_repo:
  file.managed:
    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
    - source: salt://repos/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Pool.repo
    - template: jinja
[...]
---
[CRITICAL] Rendering SLS 'base:repos.default' failed: Jinja error: argument of type 'NoneType' is not iterable
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 368, in render_jinja_tmpl
    output = template.render(**decoded_context)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 989, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/lib/python2.7/site-packages/jinja2/environment.py", line 754, in handle_exception
    reraise(exc_type, exc_value, tb) 
  File "<template>", line 178, in top-level template code
TypeError: argument of type 'NoneType' is not iterable

; line 178 
```

This PR just fixes the comparison assuming `grains['role']` is always a string.