### PR TITLE
Add right version of java fixes #378

### DIFF
--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -28,6 +28,12 @@ environment_setup_script:
     - source: salt://suse_manager_server/setup_env.sh
     - template: jinja
 
+java_ibm:
+  pkg.installed:
+    - name: java-1_8_0-ibm
+    - require:
+      - sls: repos
+
 suse_manager_setup:
   cmd.run:
     - name: /usr/lib/susemanager/bin/migration.sh -l /var/log/susemanager_setup.log -s

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -29,14 +29,11 @@ environment_setup_script:
     - template: jinja
 
 # HACK: work around bsc#1099454
-
 java_ibm:
   pkg.installed:
     - name: java-1_8_0-ibm
     - require:
       - sls: repos
-
-# end of HACK
 
 suse_manager_setup:
   cmd.run:

--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -28,11 +28,15 @@ environment_setup_script:
     - source: salt://suse_manager_server/setup_env.sh
     - template: jinja
 
+# HACK: work around bsc#1099454
+
 java_ibm:
   pkg.installed:
     - name: java-1_8_0-ibm
     - require:
       - sls: repos
+
+# end of HACK
 
 suse_manager_setup:
   cmd.run:


### PR DESCRIPTION
New commit for java issue. For some reason putting:

```
suse_manager_setup:
  cmd.run:
    - name: /usr/lib/susemanager/bin/migration.sh -l /var/log/susemanager_setup.log -s
    - creates: /root/.MANAGER_SETUP_COMPLETE
    - require:
      - pkg: suse_manager_packages
+    - pkg: java-1_8_0-ibm
      - file: environment_setup_script
      {% if grains.get('apparmor') %}
      - sls: suse_manager_server.apparmor
      {% endif %}

```
or making the suse_manager_setup require the java_ibm file, fails. Trying with just the state without the setup requiring it works for both 3.1 and 3.2 released for me.