### PR TITLE
[WIP] Adjustments for SUSE manager for retail - other network topology

### DIFF
--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -65,6 +65,14 @@ resource "libvirt_volume" "sles-es7_volume" {
   pool = "${var.pool}"
 }
 
+resource "libvirt_network" "private_network" {
+  count = "${var.retail ? 1: 0}"
+  name = "branch_network"
+  mode = "nat"
+  domain = "branch.net"
+  addresses = ["192.168.5.0/24", "fd05::/120"]
+}
+
 output "configuration" {
   depends_on = [
     "libvirt_volume.centos7_module",
@@ -88,6 +96,8 @@ output "configuration" {
     name_prefix = "${var.name_prefix}"
     use_shared_resources = "${var.use_shared_resources}"
     testsuite = "${var.testsuite}"
+    retail = "${var.retail}"
+    network_id = "${var.retail ? libvirt_network.private_network.id : ""}"
 
     // Provider-specific variables
     pool = "${var.pool}"

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -48,6 +48,11 @@ variable "testsuite" {
   default = false
 }
 
+variable "retail" {
+  description = "whether this is a SUSE Manager for Retail deployment or not"
+  default = false
+}
+
 // Provider-specific variables
 
 variable "pool" {

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -32,8 +32,9 @@ resource "libvirt_domain" "domain" {
 
   network_interface {
     wait_for_lease = true
-    network_name = "${var.base_configuration["network_name"]}"
-    bridge = "${var.base_configuration["bridge"]}"
+    network_id = "${var.base_configuration["retail"] ? var.base_configuration["network_id"] : ""}"
+    network_name = "${var.base_configuration["retail"] ? "" : var.base_configuration["network_name"]}"
+    bridge = "${var.base_configuration["retail"] ? "" : var.base_configuration["bridge"]}"
     mac = "${var.mac}"
   }
 


### PR DESCRIPTION
- Support for private network between proxy ("branch server") and clients ("terminals")

**WORK IN PROGRESS - proof of concept, not configureable yet**

In this network topology, proxy has only one network interface card, and the DHCP server is external (provided by libvirt)
