### PR TITLE
Adjustments for SUSE manager for retail - Rough network setting

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -148,6 +148,23 @@ Additionally, it is possible to have only one user to upload images and other sh
  * add a `use_shared_resources = true` variable to the `base` module of all users but one
  * make sure there is exactly one user that does not have the variable set, make sure this user has no `name_prefix` set. This user will deploy shared infrastructure for all users
 
+
+## Additional network and SUSE Manager for Retail
+
+You may get an additional, isolated, network, with neither DHCP nor DNS by specifying:
+
+```hcl
+module "base" {
+  [...]
+  additional_network = true
+  [...]
+}
+```
+
+This will create a network named `private`, with your prefix in front of the name (eg. `hmu-private`). Every VM will get a second network interface `eth1` connected to that network.
+
+You may use that additional network to test SUSE Manager for Retail with the test suite or manually.
+
 ## Custom SSH keys
 
 If you want to use another key for all VMs, specify the path of the public key with `ssh_key_path` into the `base` config. Example:

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -4,14 +4,17 @@ provider "libvirt" {
 
 module "base" {
   source = "./modules/libvirt/base"
+
   cc_username = "UC7"
   cc_password = ...
   testsuite = true
+
   // optional parameters with defaults below
   // pool = "default"
   // network_name = "default" // change to "" if you change bridge below
   // bridge = ""
   // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
+  // additional_network = false // needed for testing Retail
 }
 
 module "ctl" {

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -21,6 +21,7 @@ module "base" {
   // optional parameters with defaults below
   // name_prefix = ""
   // timezone = "Europe/Berlin"
+  // additional_network = false // needed for testing Retail
 
   // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud 
   mirror = "mirror.tf.local"

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -65,6 +65,14 @@ resource "libvirt_volume" "sles-es7_volume" {
   pool = "${var.pool}"
 }
 
+resource "libvirt_network" "additional_network" {
+  count = "${var.additional_network ? 1 : 0}"
+  name = "${var.name_prefix}private"
+  mode = "none"
+  addresses = [ "192.168.5.0/24" ]
+  dhcp { enabled = "false" }
+}
+
 output "configuration" {
   depends_on = [
     "libvirt_volume.centos7_module",
@@ -88,6 +96,8 @@ output "configuration" {
     name_prefix = "${var.name_prefix}"
     use_shared_resources = "${var.use_shared_resources}"
     testsuite = "${var.testsuite}"
+    additional_network = "${var.additional_network}"
+    additional_network_id = "${join(",", libvirt_network.additional_network.*.id)}"
 
     // Provider-specific variables
     pool = "${var.pool}"

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -48,6 +48,11 @@ variable "testsuite" {
   default = false
 }
 
+variable "additional_network" {
+  description = "whether to use an additional network or not"
+  default = false
+}
+
 // Provider-specific variables
 
 variable "pool" {

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -31,12 +31,20 @@ resource "libvirt_domain" "domain" {
     var.additional_disk
   )}"]
 
-  network_interface {
-    wait_for_lease = true
-    network_name = "${var.base_configuration["network_name"]}"
-    bridge = "${var.base_configuration["bridge"]}"
-    mac = "${var.mac}"
-  }
+  network_interface = ["${slice(
+    list(
+      map("wait_for_lease", true,
+          "network_name", var.base_configuration["network_name"],
+          "bridge", var.base_configuration["bridge"],
+          "mac", var.mac
+         ),
+      map("wait_for_lease", false,
+          "network_id", var.base_configuration["additional_network_id"]
+         )
+    ),
+    0,
+    var.base_configuration["additional_network"] ? 2 : 1
+  )}"]
 
   connection {
     user = "root"
@@ -54,6 +62,7 @@ resource "libvirt_domain" "domain" {
 hostname: ${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}
 domain: ${var.base_configuration["domain"]}
 use_avahi: ${var.base_configuration["use_avahi"]}
+additional_network: ${var.base_configuration["additional_network"]}
 timezone: ${var.base_configuration["timezone"]}
 testsuite: ${var.base_configuration["testsuite"]}
 use_released_updates: ${var.use_released_updates}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -5,7 +5,8 @@ export CLIENT={{ grains.get('client') }}
 export MINION={{ grains.get('minion') }}
 {% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION={{ grains.get('ssh_minion') }} {% else %}# no SSH minion defined {% endif %}
 {% if grains.get('centos_minion') | default(false, true) %}export CENTOSMINION={{ grains.get('centos_minion') }} {% else %}# no CentOS minion defined {% endif %}
-{% if grains.get('mirror') | default(false, true) %}export MIRROR=yes {% else %}# no mirror used {% endif %}
+{% if grains.get('additional_network') | default(false, true) %}export PRIVATENET='yes' {% else %}# no private network defined {% endif %}
+{% if grains.get('mirror') | default(false, true) %}export MIRROR='yes' {% else %}# no mirror used {% endif %}
 
 # Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -169,10 +169,6 @@ http:
   - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/Manager:/Head:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
 
-  # SLEPOS SUSE Manager for Retail devel
-  - url: http://download.suse.de/ibs/Devel:/SLEPOS:/SUSE-Manager-Retail:/Head/SLE_12_SP3/
-    archs: [x86_64]
-
   # openSUSE Leap
   - url: http://download.opensuse.org/distribution/leap/42.3/repo/oss/suse
     archs: [x86_64]

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -13,20 +13,6 @@ containers_updates_repo:
     - source: salt://repos/repos.d/SLE-Module-Containers-SLE-12-x86_64-Update.repo
     - template: jinja
 
-# Workaround: until `kiwi-desc-saltboot` is part of Manager:tools , we need
-# to manually add this repo that contains `kiwi-desc-saltboot`. Can be removed
-# when https://github.com/SUSE/spacewalk/issues/5202 is closed
-
-{% if '3.2' in grains['product_version'] or 'head' in grains['product_version'] %}
-
-slepos_devel_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
-    - source: salt://repos/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
-    - template: jinja
-
-{% endif %}
-
 {% endif %}
 
 {% if '15' in grains['osrelease'] %}

--- a/salt/repos/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
+++ b/salt/repos/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
@@ -1,7 +1,0 @@
-[Devel_SLEPOS_SUSE-Manager-Retail_Head]
-name=corresponds to git master (SLE_12_SP3)
-type=rpm-md
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/SLEPOS:/SUSE-Manager-Retail:/Head/SLE_12_SP3/
-gpgcheck=1
-gpgkey=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/SLEPOS:/SUSE-Manager-Retail:/Head/SLE_12_SP3/repodata/repomd.xml.key
-enabled=1

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -4,7 +4,9 @@ include:
 
 proxy-packages:
   pkg.latest:
-    - name: patterns-suma_proxy
+    - pkgs:
+      - patterns-suma_proxy
+      - SuSEfirewall2
     - require:
       - sls: repos
 


### PR DESCRIPTION
This pull request adds support for SUSE Manager for retail:
```
    +------------+-----------+------------+  10.160.0.0/16
    |            |           |            |
+---+----+   +---+---+   +---+----+   +---+----+
|  eth0  |   |  eth0 |   |  eth0  |   |  eth0  |
|        |   |       |   |        |   |        |
| server |   | proxy |   | client |   | minion |
|        |   |       |   |        |   |        |
+  eth1  |   |  eth1 |   |  eth1  |   |  eth1  |
+---+----+   +---+---+   +---+----+   +---+----+
    |            |           |            |
    +------------+-----------+------------+  192.168.5.0/24
```
- variable geometry bits:
  - new `retail` base setting
  - corresponding `retail` grain on the hosts
  - corresponding `$RETAIL` variable in the `.bashrc` on the host
- minimalistic network setup if in retail mode:
   - additional private network
   - a second interface to that network on each host
- hacks: needed repos and packages
  - retail "devel" repo (*)
  - branch network formula (**)
  - dhcp server and SuSEfirewall2 packages (**)

The plan is to rebase the finer setup from #383 on top of this PR.

(*) should go away when merged with suse manager
(**) should go away when we have minions as proxies
