### PR TITLE
Fix: append replaced values if not found

### DIFF
--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -108,6 +108,7 @@ enable_salt_content_staging_window:
     - name: /etc/rhn/rhn.conf
     - pattern: 'java.salt_content_staging_window = (.*)'
     - repl: 'java.salt_content_staging_window = 0.033'
+    - append_if_not_found: True
     - require:
       - cmd: suse_manager_setup
 
@@ -116,6 +117,9 @@ enable_salt_content_staging_advance:
     - name: /etc/rhn/rhn.conf
     - pattern: 'java.salt_content_staging_advance = (.*)'
     - repl: 'java.salt_content_staging_advance = 0.05'
+    - append_if_not_found: True
+    - require:
+      - cmd: suse_manager_setup
 
 enable_kiwi_os_image_building:
   file.replace:


### PR DESCRIPTION
Replaced values are not inserted into rhn.conf because Salt cannot
find them (as they are not part of the default config file).
This PR uses Salt option append_if_not_found to ensure that these
settings will land on rhn.conf