### PR TITLE
Feat: temporary workaround for kiwi-desc-saltboot

### DIFF
--- a/salt/repos/repos.d/Devel:SLEPOS:SUSE-Manager-Retail:Head.repo
+++ b/salt/repos/repos.d/Devel:SLEPOS:SUSE-Manager-Retail:Head.repo
@@ -1,0 +1,7 @@
+[Devel_SLEPOS_SUSE-Manager-Retail_Head]
+name=corresponds to git master (SLE_12_SP3)
+type=rpm-md
+baseurl=http://download.suse.de/ibs/Devel:/SLEPOS:/SUSE-Manager-Retail:/Head/SLE_12_SP3/
+gpgcheck=1
+gpgkey=http://download.suse.de/ibs/Devel:/SLEPOS:/SUSE-Manager-Retail:/Head/SLE_12_SP3/repodata/repomd.xml.key
+enabled=1

--- a/salt/repos/testsuite.sls
+++ b/salt/repos/testsuite.sls
@@ -9,6 +9,18 @@ testsuite_build_repo:
     - source: salt://repos/repos.d/Devel_Galaxy_BuildRepo.repo
     - template: jinja
 
+{% if grains['role'] == 'minion' %}
+# Workaround: until `kiwi-desc-saltboot` is part of Manager:tools , we need
+# to manually add this repo that contains `kiwi-desc-saltboot`. Can be removed
+# when https://github.com/SUSE/spacewalk/issues/5202 is closed
+
+slepos_devel_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
+    - source: salt://repos/repos.d/Devel_SLEPOS_SUSE-Manager-Retail_Head.repo
+
+{% endif %}
+
 {% elif grains['os_family'] == 'RedHat' %}
 
 testsuite_build_repo:


### PR DESCRIPTION
Workaround: until `kiwi-desc-saltboot` is part of Manager:tools , we need
to manually add this repo that contains `kiwi-desc-saltboot`. Can be removed
when https://github.com/SUSE/spacewalk/issues/5202 is closed