### PR TITLE
Using new branch Manager-3.2 as default when needed

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -4,8 +4,8 @@ variable "testsuite-branch" {
     "3.0-nightly" = "Manager-3.0"
     "3.1-released" = "Manager-3.1"
     "3.1-nightly" = "Manager-3.1"
-    "3.2-released" = "Manager"
-    "3.2-nightly" = "Manager"
+    "3.2-released" = "Manager-3.2"
+    "3.2-nightly" = "Manager-3.2"
     "head" = "Manager"
     "test" = "Manager"
   }


### PR DESCRIPTION
Now we have a `Manager-3.2` branch for spacewalk, we can use it in the test suite controller in case we have requested `3.2-nightly` or `3.2-released` product version.