### PR TITLE
[Depends on PR#387] Two more changes for terraform v11

### DIFF
--- a/salt/minion/testsuite.sls
+++ b/salt/minion/testsuite.sls
@@ -53,7 +53,7 @@ update_ca_truststore:
     - require:
       - pkg: suse_minion_cucumber_requisites
 
-{% if '3.2' in grains['version'] or 'head' in grains['version'] %}
+{% if '3.2' in grains['product_version'] or 'head' in grains['product_version'] %}
 
 kiwi-desc-saltboot-installed:
   pkg.installed:

--- a/salt/repos/minion.sls
+++ b/salt/repos/minion.sls
@@ -16,8 +16,7 @@ containers_updates_repo:
 # Workaround: until `kiwi-desc-saltboot` is part of Manager:tools , we need
 # to manually add this repo that contains `kiwi-desc-saltboot`. Can be removed
 # when https://github.com/SUSE/spacewalk/issues/5202 is closed
-
-{% if '3.2' in grains['version'] or 'head' in grains['version'] %}
+{% if '3.2' in grains['product_version'] or 'head' in grains['product_version'] %}
 
 slepos_devel_repo:
   file.managed:


### PR DESCRIPTION
Transition from `version` to `product_version` in a line that is not covered by Dario's PR (#387).

