### PR TITLE
Fixes for new CentOS 7

### DIFF
--- a/packer/centos7.json
+++ b/packer/centos7.json
@@ -40,7 +40,7 @@
       "disk_interface": "virtio",
       "net_device": "virtio-net-pci",
       "boot_command": [
-        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_centos7.cfg<enter><wait>"
+        "<tab> text inst.sshd ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_centos7.cfg<enter><wait>"
       ]
     }]
 }

--- a/packer/centos7.json
+++ b/packer/centos7.json
@@ -14,7 +14,7 @@
   "builders": [{
       "name": "centos7",
       "type": "qemu",
-      "iso_checksum": "bba314624956961a2ea31dd460cd860a77911c1e0a56e4820a12b9c5dad363f5",
+      "iso_checksum": "714acc0aefb32b7d51b515e25546835e55a90da9fb00417fbee2d03a62801efd",
       "iso_checksum_type": "sha256",
       "iso_url": "http://mirror2.hs-esslingen.de/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso",
       "ssh_wait_timeout": "30s",

--- a/packer/centos7.json
+++ b/packer/centos7.json
@@ -23,8 +23,7 @@
       "format": "qcow2",
       "qemuargs": [
         [ "-m", "1024M" ],
-        ["-machine", "type=pc,accel=kvm"],
-        ["-device", "virtio-net-pci,netdev=user.0"]
+        ["-machine", "type=pc,accel=kvm"]
       ],
       "headless": true,
       "accelerator": "kvm",
@@ -39,6 +38,7 @@
       "ssh_wait_timeout": "90m",
       "vm_name": "centos7",
       "disk_interface": "virtio",
+      "net_device": "virtio-net-pci",
       "boot_command": [
         "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks_centos7.cfg<enter><wait>"
       ]


### PR DESCRIPTION
* correct checksum for new image (*)
* start sshd explicitely on kernel command line
* cosmetical syntax change

(*) GPG signature was checked, but without the CentOS CA