### PR TITLE
Use phantomjs and twopence from systemsmanagement-sumaform-tools so they are available for public CI

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -179,10 +179,6 @@ http:
   - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP3
     archs: [x86_64]
 
-  # Testsuite Controller repo
-  - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/cucumber-testsuite/openSUSE_Leap_42.3/
-    archs: [x86_64]
-
   # Testsuite dummy packages for testing repo
   - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1
     archs: [x86_64]

--- a/salt/repos/controller.sls
+++ b/salt/repos/controller.sls
@@ -2,8 +2,8 @@
 
 Devel_Galaxy_cucumber_testsuite_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/Devel_Galaxy_cucumber_testsuite.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_cucumber_testsuite.repo
+    - name: /etc/zypp/repos.d/systemsmanagement-sumaform-tools.repo
+    - source: salt://repos/repos.d/systemsmanagement-sumaform-tools.repo
     - template: jinja
 
 {% endif %}

--- a/salt/repos/repos.d/Devel_Galaxy_cucumber_testsuite.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_cucumber_testsuite.repo
@@ -1,5 +1,0 @@
-[Devel_Galaxy_cucumber_testsuite]
-name=Packages needed for the Cucumber testsuite
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/cucumber-testsuite/openSUSE_Leap_42.3/


### PR DESCRIPTION
Fixes #403 

Packages are already available at https://build.opensuse.org/project/show/systemsmanagement:sumaform:tools