### PR TITLE
Now osmajorrelease grain is an integer

### DIFF
--- a/salt/default/hostname.sls
+++ b/salt/default/hostname.sls
@@ -41,7 +41,7 @@ hosts_file_hack:
     - args: "{{ grains['hostname'] }} {{ grains['domain'] }}"
     - template: jinja
     - context:
-    {% if grains.get('osmajorrelease', None)|int() == 15 %}
+    {% if grains.get('osmajorrelease', None) == 15 %}
       pythonexec: python3
     {% else %}
       pythonexec: python

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -303,7 +303,7 @@ galaxy_key:
     - watch:
       - file: galaxy_key
 
-{% if grains['osmajorrelease'] == '7' %}
+{% if grains['osmajorrelease'] == 7 %}
 tools_pool_repo:
   file.managed:
     - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-x86_64.repo
@@ -348,7 +348,7 @@ tools_update_repo:
     - require:
       - cmd: galaxy_key
 {% endif %}
-{% endif %} {# grains['osmajorrelease'] == '7' #}
+{% endif %} {# grains['osmajorrelease'] == 7 #}
 
 {% endif %} {# grains['os_family'] == 'RedHat' #}
 


### PR DESCRIPTION
This is the root cause to the CentOS problems: now Salt defines `osmajorrelease`as an integer and not as a string anymore.