### PR TITLE
Added CentOS repos for 3.1

### DIFF
--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -321,11 +321,38 @@ suse_res7_key:
     - watch:
       - file: suse_res7_key
 
-{% if '3.2-released' in grains.get('product_version') | default('', true) %}
+{% if '3.1-released' in grains.get('product_version') | default('', true) %}
 tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
     - source: salt://repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+    - template: jinja
+    - require:
+      - cmd: galaxy_key
+
+{% elif '3.1-nightly' in grains.get('product_version') | default('', true) %}
+tools_update_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+    - template: jinja
+    - require:
+      - cmd: galaxy_key
+
+{% elif '3.2-released' in grains.get('product_version') | default('', true) %}
+tools_update_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+    - source: salt://repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+    - template: jinja
+    - require:
+      - cmd: galaxy_key
+
+{% elif '3.2-nightly' in grains.get('product_version') | default('', true) %}
+tools_update_repo:
+  file.managed:
+    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
+    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
     - template: jinja
     - require:
       - cmd: galaxy_key
@@ -339,14 +366,6 @@ tools_update_repo:
     - require:
       - cmd: galaxy_key
 
-{% elif 'nightly' in grains.get('product_version') | default('', true) %}
-tools_update_repo:
-  file.managed:
-    - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
-    - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo
-    - template: jinja
-    - require:
-      - cmd: galaxy_key
 {% endif %}
 {% endif %} {# grains.get('osmajorrelease', None)|int() == 7 #}
 

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -321,29 +321,11 @@ suse_res7_key:
     - watch:
       - file: suse_res7_key
 
-{% if '3.1-released' in grains.get('product_version') | default('', true) %}
-tools_update_repo:
-  file.managed:
-    - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
-    - source: salt://repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
-    - template: jinja
-    - require:
-      - cmd: galaxy_key
-
-{% elif '3.1-nightly' in grains.get('product_version') | default('', true) %}
+{% if '3.1-nightly' in grains.get('product_version') | default('', true) %}
 tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
-    - template: jinja
-    - require:
-      - cmd: galaxy_key
-
-{% elif '3.2-released' in grains.get('product_version') | default('', true) %}
-tools_update_repo:
-  file.managed:
-    - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
-    - source: salt://repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
     - template: jinja
     - require:
       - cmd: galaxy_key

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64.repo
@@ -1,0 +1,5 @@
+[Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64]
+name=Devel_Galaxy_Manager_3.1_RES-Manager-Tools-7-x86_64
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("dist.nue.suse.com", true) }}/ibs/Devel:/Galaxy:/Manager:/3.1:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard/

--- a/salt/repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+++ b/salt/repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
@@ -1,6 +1,0 @@
-[SLE-Manager-Tools-RES-7-Beta-x86_64]
-name=SLE-Manager-Tools-RES-7-Beta-x86_64
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC3/RES7/x86_64
-priority=98


### PR DESCRIPTION
We were putting 3.2 repos on 3.1 CentOS.

I am not sure at all about the difference between
  `Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-x86_64.repo`
and
  `Devel_Galaxy_Manager_3.2_RES-Manager-Tools-7-Beta-x86_64.repo`.

I suspect an error there. Cen you please review that too?