### PR TITLE
Remove beta repos

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -137,18 +137,6 @@ http:
   - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/Manager:/3.2:/RES7-SUSE-Manager-Tools/SUSE_RES-7_Update_standard
     archs: [x86_64]
 
-  # SLE 11 SP4 Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC3/SLE11SP4/x86_64/update
-    archs: [x86_64]
-
-  # SLE 12 (GA and all SPs) Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC3/SLE12/x86_64/update
-    archs: [x86_64]
-
-  # RES 7 Manager Tools 3.2 beta
-  - url: http://beta.suse.com/private/SUSE-Manager-beta/GMC3/RES7/x86_64
-    archs: [x86_64]
-
   # SUSE Manager Head devel
   - url: http://dist.nue.suse.com/ibs/Devel:/Galaxy:/Manager:/Head/SLE_12_SP3
     archs: [x86_64]
@@ -212,4 +200,3 @@ http:
   # Uyuni Proxy
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
     archs: [x86_64]
-

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -56,15 +56,7 @@ tools_pool_repo:
     - source: salt://repos/repos.d/SLE-Manager-Tools-SLE-11-x86_64.repo
     - template: jinja
 
-{% if '3.2-released' in grains.get('product_version') | default('', true) %}
-
-tools_additional_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
-    - source: salt://repos/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
-    - template: jinja
-
-{% elif 'nightly' in grains.get('product_version') | default('', true) %}
+{% if 'nightly' in grains.get('product_version') | default('', true) %}
 
 tools_additional_repo:
   file.managed:
@@ -188,15 +180,7 @@ tools_update_repo:
     - source: salt://repos/repos.d/SLE-Manager-Tools-SLE-12-x86_64-Update.repo
     - template: jinja
 
-{% if '3.2-released' in grains.get('product_version') | default('', true) %}
-
-tools_additional_repo:
-  file.managed:
-    - name: /etc/zypp/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
-    - source: salt://repos/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
-    - template: jinja
-
-{% elif 'nightly' in grains.get('product_version') | default('', true) %}
+{% if 'nightly' in grains.get('product_version') | default('', true) %}
 
 tools_additional_repo:
   file.managed:
@@ -321,16 +305,7 @@ suse_res7_key:
     - watch:
       - file: suse_res7_key
 
-{% if '3.2-released' in grains.get('product_version') | default('', true) %}
-tools_update_repo:
-  file.managed:
-    - name: /etc/yum.repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
-    - source: salt://repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
-    - template: jinja
-    - require:
-      - cmd: galaxy_key
-
-{% elif 'head' in grains.get('product_version') | default('', true) %}
+{% if 'head' in grains.get('product_version') | default('', true) %}
 tools_update_repo:
   file.managed:
     - name: /etc/yum.repos.d/Devel_Galaxy_Manager_Head_RES-Manager-Tools-7-x86_64.repo

--- a/salt/repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
+++ b/salt/repos/repos.d/SLE-Manager-Tools-RES-7-Beta-x86_64.repo
@@ -1,6 +1,0 @@
-[SLE-Manager-Tools-RES-7-Beta-x86_64]
-name=SLE-Manager-Tools-RES-7-Beta-x86_64
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC3/RES7/x86_64
-priority=98

--- a/salt/repos/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
+++ b/salt/repos/repos.d/SLE-Manager-Tools-SLE-11-Beta-x86_64.repo
@@ -1,6 +1,0 @@
-[SLE-Manager-Tools-SLE-11-Beta-x86_64]
-name=SLE-Manager-Tools-SLE-11-Beta-x86_64
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC3/SLE11SP4/x86_64/update
-priority=98

--- a/salt/repos/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
+++ b/salt/repos/repos.d/SLE-Manager-Tools-SLE-12-Beta-x86_64.repo
@@ -1,6 +1,0 @@
-[SLE-Manager-Tools-SLE-12-Beta-x86_64]
-name=SLE-Manager-Tools-SLE-12-Beta-x86_64
-type=rpm-md
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("beta.suse.com", true) }}/private/SUSE-Manager-beta/GMC3/SLE12/x86_64/update
-priority=98


### PR DESCRIPTION
This removes repos used during the beta phase of SUSE Manager 3.2.

Fixes  #422

cc @Bischoff 