### PR TITLE
Allow using a custom test repository

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -45,6 +45,16 @@ module "suma31pg" {
 }
 ```
 
+The repository used for the `test` product can be forced to any open build service project using the
+`product_test_repository` variable. The following example will use the packages from `home:foobar:Galaxy_test`
+
+```hcl
+module 'srv' {
+  product_version = "test"
+  product_test_repository = "https://download.opensuse.org/repositories/home:/foobar:/Galaxy_test/Leap_15/"
+}
+```
+
 ## Multiple VMs of the same type
 
 Some modules, for example clients and minions, support a `count` variable that allows you to create several instances at once. For example:

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -27,6 +27,7 @@ module "suse_manager" {
   grains = <<EOF
 
 product_version: ${var.product_version}
+product_test_repository: ${var.product_test_repository}
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 channels: [${join(",", var.channels)}]

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -13,6 +13,12 @@ variable "product_version" {
   type = "string"
 }
 
+variable "product_test_repository" {
+  description = "an OBS repository to use to install the product instead of the regular test one."
+  type = "string"
+  default = "null"
+}
+
 variable "channels" {
   description = "a list of SUSE channel labels to add"
   default = []

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -27,6 +27,7 @@ module "suse_manager" {
   grains = <<EOF
 
 product_version: ${var.product_version}
+product_test_repository: ${var.product_test_repository}
 cc_username: ${var.base_configuration["cc_username"]}
 cc_password: ${var.base_configuration["cc_password"]}
 channels: [${join(",", var.channels)}]

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -13,6 +13,12 @@ variable "product_version" {
   type = "string"
 }
 
+variable "product_test_repository" {
+  description = "an OBS repository to use to install the product instead of the regular test one."
+  type = "string"
+  default = "null"
+}
+
 variable "channels" {
   description = "a list of SUSE channel labels to add"
   default = []

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -274,6 +274,13 @@ allow_vendor_changes:
         vendors = SUSE,openSUSE Build Service,obs://build.suse.de/Devel:Galaxy,obs://build.opensuse.org
   {% endif %}
 
+{% if grains.get('product_version') == 'test' %}
+allow_all_vendor_changes:
+  file.append:
+    - name: /etc/zypp/zypp.conf
+    - text: solver.allowVendorChange = true
+{% endif %}
+
 {% endif %}
 
 {% if grains['os_family'] == 'RedHat' %}

--- a/salt/repos/repos.d/Devel_Galaxy_Manager_TEST.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_Manager_TEST.repo
@@ -2,5 +2,9 @@
 name=Devel Project for SUSE Manager TEST (SLE_12_SP3)
 type=rpm-md
 enabled=1
+{% if grains.get("product_test_repository") %}
+baseurl={{ grains.get("product_test_repository") }}
+{% else %}
 baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_12_SP3/
+{% endif %}
 priority=95


### PR DESCRIPTION
Sicne the official test repository is rather busy, hackers may want to
use their own OBS repository to test their new SUSE Manager / Uyuni
features.

For this, introduce a new product_test_repository variable. Since zypper
will be confused with salt vendors change, don't use sticky vendors in
test mode.