### PR TITLE
Add support for serial consoles

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -29,6 +29,11 @@ timezone_setting:
     - require:
       - file: timezone_symlink
 
+# serial_console:
+#   service.running:
+#     - name: serial-getty@ttyS0
+#     - enable: True
+
 {% if grains.get('use_unreleased_updates') | default(False, true) or grains.get('use_released_updates') | default(False, true) %}
 update_packages:
   pkg.uptodate:


### PR DESCRIPTION
(extracted from #432 from @MalloZup )

This PR adds a serial console to our VMs. It enables:
* to use `virsh console` to connect to a VM, especially when network is unavailable
* to avoid Ubuntu to run at 100% CPU and become unusable