### PR TITLE
Fix error on CentOS 7

### DIFF
--- a/packer/scripts/cleanup.sh
+++ b/packer/scripts/cleanup.sh
@@ -4,3 +4,6 @@ yum -y clean all
 # Remove traces of mac address from network configuration
 sed -i /HWADDR/d /etc/sysconfig/network-scripts/ifcfg-eth0
 rm -f /etc/udev/rules.d/70-persistent-net.rules
+
+# Since there is no MAC address anymore, we need to identify the card
+echo 'DEVICE="eth0"' >> /etc/sysconfig/network-scripts/ifcfg-eth0


### PR DESCRIPTION
When running latest CentOS 7 image (v3) on production servers, I get message
  `Device eth0 does not seem to be present, delaying initialisation`
when I do `# ifup eth0`.

Root cause is that we remove the MAC address of the VM from `ifcfg-eth0`, because the running terraform machine will have a different MAC than the packer VM. That's fine, but then the recent RedHat scripts don't know how to identify the card anymore. This PR solves the issue simply by adding `DEVICE=eth0` to `ifcfg-eth0`.

Note: I checked, this is independent from the removal of `TYPE="Ethernet"`. That removal is still needed.


Mode nightmare on: this means rebuilding the images again :scream_cat:.
