### PR TITLE
Add new minion that is acquired through PXE booting (two modules)

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -460,6 +460,43 @@ module "vanilla" {
 }
 ```
 
+## Unprovisioned hosts
+
+Plain hosts still have some provisioning, for example SSH keys. If you want completely
+unprovisioned hosts (no initialization with Salt), use the `unprovisioned` module.
+
+A libvirt example follows:
+
+```hcl
+module "unprovisioned" {
+  source = "./modules/libvirt/unprovisioned"
+  base_configuration = "${module.base.configuration}"
+
+  name = "unprovisioned"
+  image = "sles12sp3"
+}
+```
+
+### PXE boot hosts
+
+PXE boot hosts are special unprovisioned hosts that are capable
+of booting on their networking card. Additionally, they have a hardware
+type of "Genuine Intel" to make provisioning via Retail easier.
+
+A libvirt example follows:
+
+```hcl
+module "pxeboot"
+{
+  source = "sumaform/modules/libvirt/pxe_boot"
+  base_configuration = "${module.base.configuration}"
+
+  name = "pxeboot"
+  image = "sles12sp3"
+}
+```
+
+
 ## `minionswarm` hosts
 
 It is possible to create large numbers of simulated minions using Salt's [minionswarm test script](https://docs.saltstack.com/en/latest/topics/releases/0.9.9.html#minionswarm).

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -27,6 +27,7 @@ module "ctl" {
   minion_configuration = "${module.min-sles12sp3.configuration}"
   centos_configuration = "${module.min-centos7.configuration}"         // optional
   minionssh_configuration = "${module.minssh-sles12sp3.configuration}" // optional
+  pxeboot_configuration = "${module.pxeboot-sles12sp3.configuration}"  // optional
   branch = "default"
   // credentials available in https://gitlab.suse.de/galaxy/sumaform-test-runner/blob/master/31/main-full.tf
   git_username = ...
@@ -97,4 +98,13 @@ module "min-centos7" {
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
+}
+
+# optional
+module "pxeboot-sles12sp3"
+{
+  source = "sumaform/modules/libvirt/pxe_boot"
+  base_configuration = "${module.base.configuration}"
+  name = "pxeboot-sles12sp3"
+  image = "sles12sp3"
 }

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -34,6 +34,7 @@ client: ${var.client_configuration["hostname"]}
 minion: ${var.minion_configuration["hostname"]}
 centos_minion: ${var.centos_configuration["hostname"]}
 ssh_minion: ${var.minionssh_configuration["hostname"]}
+pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -68,6 +68,14 @@ variable "centos_configuration" {
   }
 }
 
+variable "pxeboot_configuration" {
+  description = "use ${module.<PXEBOOT_NAME>.configuration}, see main.tf.libvirt-testsuite.example"
+  type = "map"
+  default = {
+    hostname = "null"
+  }
+}
+
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}, see README_ADVANCED.md"
   default = {}

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -125,5 +125,6 @@ output "configuration" {
   value {
     id = "${libvirt_domain.domain.0.id}"
     hostname = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-1" : ""}.${var.base_configuration["domain"]}"
+    macaddr = "${libvirt_domain.domain.0.network_interface.0.mac}"
   }
 }

--- a/modules/libvirt/pxe_boot/main.tf
+++ b/modules/libvirt/pxe_boot/main.tf
@@ -1,0 +1,21 @@
+module "pxe_boot" {
+  source = "../unprovisioned"
+
+  base_configuration = "${var.base_configuration}"
+  name = "${var.name}"
+  count = "${var.count}"
+  connect_to_base_network = false
+  connect_to_additional_network = true
+
+  // Provider-specific variables
+  image = "${var.image}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  mac = "${var.mac}"
+  pxe = true
+}
+
+output "configuration" {
+  value = "${module.pxe_boot.configuration}"
+}

--- a/modules/libvirt/pxe_boot/variables.tf
+++ b/modules/libvirt/pxe_boot/variables.tf
@@ -1,0 +1,41 @@
+variable "base_configuration" {
+  description = "use ${module.base.configuration}, see the main.tf example file"
+  type = "map"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type = "string"
+}
+
+variable "count"  {
+  description = "number of hosts like this one"
+  default = 1
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
+  type = "string"
+}
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 768
+}
+
+variable "vcpu" {
+  description = "Number of virtual CPUs"
+  default = 1
+}
+
+variable "running" {
+  description = "Whether this host should be turned on or off"
+  default = true
+}
+
+variable "mac" {
+  description = "a MAC address in the form AA:BB:CC:11:22:22"
+  default = ""
+}

--- a/modules/libvirt/unprovisioned/main.tf
+++ b/modules/libvirt/unprovisioned/main.tf
@@ -1,0 +1,63 @@
+terraform {
+    required_version = "~> 0.11.7"
+}
+
+// Names are calculated as follows:
+// ${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}
+// This means:
+//   name_prefix + name (if count = 1)
+//   name_prefix + name + "-" + index (if count > 1)
+
+resource "libvirt_volume" "main_disk" {
+  name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-main-disk"
+  base_volume_name = "${var.base_configuration["use_shared_resources"] ? "" : var.base_configuration["name_prefix"]}${var.image}"
+  pool = "${var.base_configuration["pool"]}"
+  count = "${var.count}"
+}
+
+resource "libvirt_domain" "domain" {
+  name = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}"
+  memory = "${var.memory}"
+  vcpu = "${var.vcpu}"
+  running = "${var.running}"
+  count = "${var.count}"
+  qemu_agent = true
+
+  // base disk + additional disks if any
+  disk = ["${concat(
+    list(
+      map("volume_id", "${element(libvirt_volume.main_disk.*.id, count.index)}")
+    ),
+    var.additional_disk
+  )}"]
+
+  network_interface = ["${slice(
+    list(
+      map("wait_for_lease", true,
+          "network_name", var.base_configuration["network_name"],
+          "bridge", var.base_configuration["bridge"],
+          "mac", var.mac
+         ),
+      map("wait_for_lease", false,
+          "network_id", var.base_configuration["additional_network_id"]
+         )
+    ),
+    var.connect_to_base_network ? 0 : 1,
+    (var.base_configuration["additional_network"] && var.connect_to_additional_network) ? 2 : 1
+  )}"]
+
+  xml {
+    xslt = "${file(
+      var.pxe ?
+      "${path.module}/pxe.xsl" :
+      "${path.module}/noop.xsl")}"
+  }
+}
+
+output "configuration" {
+  value {
+    id = "${libvirt_domain.domain.0.id}"
+    hostname = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-1" : ""}.${var.base_configuration["domain"]}"
+    macaddr = "${libvirt_domain.domain.0.network_interface.0.mac}"
+  }
+}

--- a/modules/libvirt/unprovisioned/noop.xsl
+++ b/modules/libvirt/unprovisioned/noop.xsl
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/modules/libvirt/unprovisioned/pxe.xsl
+++ b/modules/libvirt/unprovisioned/pxe.xsl
@@ -1,0 +1,73 @@
+<?xml version="1.0" ?>
+<!-- Transformation of libvirt definition for PXE-booted machines -->
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+
+  <!-- Machine type = Genuine Intel -->
+  <xsl:template match="/domain/os">
+    <xsl:element name="sysinfo">
+      <xsl:attribute name="type">smbios</xsl:attribute>
+      <xsl:text>&#x0A;    </xsl:text>
+      <xsl:element name="system">
+        <xsl:text>&#x0A;      </xsl:text>
+        <xsl:element name="entry">
+          <xsl:attribute name="name">manufacturer</xsl:attribute>
+          <xsl:text>Intel</xsl:text>
+        </xsl:element>
+        <xsl:text>&#x0A;      </xsl:text>
+        <xsl:element name="entry">
+          <xsl:attribute name="name">product</xsl:attribute>
+          <xsl:text>Genuine</xsl:text>
+        </xsl:element>
+        <xsl:text>&#x0A;    </xsl:text>
+      </xsl:element>
+      <xsl:text>&#x0A;  </xsl:text>
+    </xsl:element>
+    <xsl:text>&#x0A;  </xsl:text>
+    <xsl:element name="os">
+      <xsl:text>&#x0A;    </xsl:text>
+      <xsl:element name="smbios">
+        <xsl:attribute name="mode">sysinfo</xsl:attribute>
+      </xsl:element>
+      <xsl:text>&#x0A;    </xsl:text>
+      <xsl:element name="bootmenu">
+        <xsl:attribute name="enable">yes</xsl:attribute>
+      </xsl:element>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Boot order = 2 for disk -->
+  <xsl:template match="/domain/devices/disk[@device = 'disk']">
+    <xsl:element name="disk">
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:text>  </xsl:text>
+      <xsl:element name="boot">
+        <xsl:attribute name="order">2</xsl:attribute>
+      </xsl:element>
+      <xsl:text>&#x0A;    </xsl:text>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Boot order = 1 for network -->
+  <xsl:template match="/domain/devices/interface[@type = 'network']">
+    <xsl:element name="interface">
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:text>  </xsl:text>
+      <xsl:element name="boot">
+        <xsl:attribute name="order">1</xsl:attribute>
+      </xsl:element>
+      <xsl:text>&#x0A;    </xsl:text>
+    </xsl:element>
+  </xsl:template>
+
+  <!-- Copy the rest -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/modules/libvirt/unprovisioned/variables.tf
+++ b/modules/libvirt/unprovisioned/variables.tf
@@ -1,0 +1,61 @@
+variable "base_configuration" {
+  description = "use ${module.base.configuration}, see the main.tf example file"
+  type = "map"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type = "string"
+}
+
+variable "count"  {
+  description = "number of hosts like this one"
+  default = 1
+}
+
+variable "connect_to_base_network" {
+  description = "true if you want a card connected to the main network, see README_ADVANCED.md"
+  default = true
+}
+
+variable "connect_to_additional_network" {
+  description = "true if you want a card connected to the additional network (if any), see README_ADVANCED.md"
+  default = false
+}
+
+// Provider-specific variables
+
+variable "image" {
+  description = "One of: sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
+  type = "string"
+}
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default = 768
+}
+
+variable "vcpu" {
+  description = "Number of virtual CPUs"
+  default = 1
+}
+
+variable "running" {
+  description = "Whether this host should be turned on or off"
+  default = true
+}
+
+variable "mac" {
+  description = "a MAC address in the form AA:BB:CC:11:22:22"
+  default = ""
+}
+
+variable "additional_disk" {
+  description = "disk block definition(s) to be added to this host"
+  default = []
+}
+
+variable "pxe" {
+  description = "machine set up for PXE booting or not"
+  default = false
+}

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -5,6 +5,7 @@ export CLIENT="{{ grains.get('client') }}"
 export MINION="{{ grains.get('minion') }}"
 {% if grains.get('ssh_minion') | default(false, true) %}export SSHMINION="{{ grains.get('ssh_minion') }}" {% else %}# no SSH minion defined {% endif %}
 {% if grains.get('centos_minion') | default(false, true) %}export CENTOSMINION="{{ grains.get('centos_minion') }}" {% else %}# no CentOS minion defined {% endif %}
+{% if grains.get('pxeboot_mac') | default(false, true) %}export PXEBOOTMAC="{{ grains.get('pxeboot_mac') }}" {% else %}# no JeOS minion defined {% endif %}
 {% if grains.get('additional_network') | default(false, true) %}export PRIVATENET="yes" {% else %}# no private network defined {% endif %}
 {% if grains.get('mirror') | default(false, true) %}export MIRROR="yes" {% else %}# no mirror used {% endif %}
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"


### PR DESCRIPTION
This PR defines two new modules:
* `unprovisioned`: like `host`, but no Salt at all for an authentic vanilla flavor 🍨 
* `pxe_boot`: a kind of unprovisioned host that can boot on its network card

Superseded by #451 (same, but only one module).