### PR TITLE
Use Uyuni repos for test product too

### DIFF
--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -101,14 +101,24 @@ suse_manager_devel_repo:
 {% if 'test' in grains['product_version'] %}
 suse_manager_pool_repo:
   file.managed:
+    {% if grains['osfullname'] == 'Leap' %}
+    - name: /etc/zypp/repos.d/Uyuni-Master-x86_64-Pool.repo
+    - source: salt://repos/repos.d/Uyuni-Master-x86_64-Pool.repo
+    {% else %}
     - name: /etc/zypp/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
     - source: salt://repos/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
+    {% endif %}
     - template: jinja
 
 suse_manager_devel_repo:
   file.managed:
+    {% if grains['osfullname'] == 'Leap' %}
+    - name: /etc/zypp/repos.d/systemsmanagement_Uyuni_Master.repo
+    - source: salt://repos/repos.d/systemsmanagement_Uyuni_Master.repo
+    {% else %}
     - name: /etc/zypp/repos.d/Devel_Galaxy_Manager_Head.repo
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_Head.repo
+    {% endif %}
     - template: jinja
 
 suse_manager_test_repo:


### PR DESCRIPTION
When using 'test' as product repo and an opensuse image for the server,
we don't want to have SUSE Manager repos: mixing both Uyuni and SUSE
Manager repos doesn't fly.

Just like Head, switch to Uyuni repos if the server is an opensuse one.