### PR TITLE
Use new name of "head" branch

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -6,9 +6,9 @@ variable "testsuite-branch" {
     "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
-    "head" = "Manager"
-    "test" = "Manager"
-    "uyuni-released" = "Manager"
+    "head" = "master"
+    "test" = "master"
+    "uyuni-released" = "master"
   }
 }
 

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -6,9 +6,9 @@ variable "testsuite-branch" {
     "3.1-nightly" = "Manager-3.1"
     "3.2-released" = "Manager-3.2"
     "3.2-nightly" = "Manager-3.2"
-    "head" = "Manager"
-    "test" = "Manager"
-    "uyuni-released" = "Manager"
+    "head" = "master"
+    "test" = "master"
+    "uyuni-released" = "master"
   }
 }
 

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -82,7 +82,7 @@ install_gems_via_bundle:
 spacewalk_git_repository:
   cmd.run:
 {%- if grains.get("git_repo") == "default" %}
-{%- if grains.get("branch") == "Manager" %}
+{%- if grains.get("branch") == "master" %}
     - name: git clone --depth 1 https://github.com/uyuni-project/uyuni.git -b master /root/spacewalk
 {%- else %}
     - name: git clone --depth 1 https://github.com/SUSE/spacewalk -b {{ grains.get("branch") }} /root/spacewalk


### PR DESCRIPTION
This PR renames "Manager" into "master", since this branch does not exist for some time now. Furthermore, newcomers to Uyuni won't have the history for this name.

There is a related PR for the runner:
https://gitlab.suse.de/galaxy/sumaform-test-runner/merge_requests/67

As this will break the `main.tf`file for everyone, the plan is to send an email to the susemanager mailing list.