### PR TITLE
Enable only eth0 for avahi

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -1,36 +1,50 @@
 include:
   - default.hostname
 
-avahi:
+avahi_pkg:
   pkg.installed:
     {%- if grains['os_family'] == 'Debian' %}
     - name: avahi-daemon
     {% else %}
     - name: avahi
     {% endif %}
+
+avahi_change_domain:
   file.replace:
     - name: /etc/avahi/avahi-daemon.conf
     - pattern: "#domain-name=local"
     - repl: "domain-name={{ grains['domain'] }}"
-  service.running:
-    - name: avahi-daemon
     - require:
       - pkg: avahi
-      - file: avahi
-    - watch:
-      - file: /etc/avahi/avahi-daemon.conf
 
-avahi_resolution_configuration:
+avahi_restrict_interfaces:
   file.replace:
-    - name: /etc/nsswitch.conf
-    - pattern: "(hosts: .*?)mdns([46]?)_minimal(.*)"
-    - repl: "\\1mdns\\2\\3"
+    - name: /etc/avahi/avahi-daemon.conf
+    - pattern: "#allow-interfaces=eth0"
+    - repl: "allow-interfaces=eth0"
     - require:
       - pkg: avahi
 
-mdns_allow_file:
+mdns_declare_domains:
   file.append:
     - name: /etc/mdns.allow
     - text:
       - .local
       - .tf.local
+
+nsswitch_enable_mdns:
+  file.replace:
+    - name: /etc/nsswitch.conf
+    - pattern: "(hosts: .*?)mdns([46]?)_minimal(.*)"
+    - repl: "\\1mdns\\2\\3"
+
+avahi_service:
+  service.running:
+    - name: avahi-daemon
+    - require:
+      - file: avahi_change_domain
+      - file: avahi_restrict_interfaces
+      - file: mdns_declare_domains
+      - file: nsswitch_enable_mdns
+    - watch:
+      - file: /etc/avahi/avahi-daemon.conf


### PR DESCRIPTION
On machines with several network cards, avahi listens on all. This patch enables avahi only on eth0.

This should prevent this problem encountered by @lkotek:
```
ebischoff@ix64ph1078:~> ping lko-proxy.tf.local    
PING lko-proxy.tf.local (192.168.8.254) 56(84) bytes of data.
```

The address `192.168.8.254` is on private network (`eth1`) and unreachable from controller and server.
