### PR TITLE
Disable private network interfaces

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -20,8 +20,8 @@ avahi_change_domain:
 avahi_restrict_interfaces:
   file.replace:
     - name: /etc/avahi/avahi-daemon.conf
-    - pattern: "#allow-interfaces=eth0"
-    - repl: "allow-interfaces=eth0"
+    - pattern: "#deny-interfaces=eth1"
+    - repl: "deny-interfaces=eth1,ens4"
     - require:
       - pkg: avahi
 


### PR DESCRIPTION
On some systems like Ubuntu there is no `eth0` but instead `ens3`. Rather than enabling only `eth0`, disable `eth1`and `ens4`.

BTW, there are 5 other occurrences of  `eth0` in sumaform :cry: .
