### PR TITLE
Feat: switch Uyuni to OpenSUSE 15.0 as base image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /terraform.tfstate*
 /.terraform/
 /main.tf
+.terraform.tfstate.lock.info

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -18,7 +18,7 @@ resource "libvirt_volume" "opensuse423_volume" {
 
 resource "libvirt_volume" "opensuse150_volume" {
   name = "${var.name_prefix}opensuse150"
-  source = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2"
+  source = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64-0.1.0-Buildlp150.1.1.qcow2"
   count = "${var.use_shared_resources ? 0 : (contains(var.images, "opensuse150") ? 1 : 0)}"
   pool = "${var.pool}"
 }

--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -16,6 +16,13 @@ resource "libvirt_volume" "opensuse423_volume" {
   pool = "${var.pool}"
 }
 
+resource "libvirt_volume" "opensuse150_volume" {
+  name = "${var.name_prefix}opensuse150"
+  source = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse150.x86_64.qcow2"
+  count = "${var.use_shared_resources ? 0 : (contains(var.images, "opensuse150") ? 1 : 0)}"
+  pool = "${var.pool}"
+}
+
 resource "libvirt_volume" "sles15_volume" {
   name = "${var.name_prefix}sles15"
   source = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15.x86_64.qcow2"
@@ -91,6 +98,7 @@ output "configuration" {
   depends_on = [
     "libvirt_volume.centos7_volume",
     "libvirt_volume.opensuse423_volume",
+    "libvirt_volume.opensuse150_volume",
     "libvirt_volume.sles15_volume",
     "libvirt_volume.sles15sp1_volume",
     "libvirt_volume.sles11sp4_volume",

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -72,6 +72,6 @@ variable "bridge" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default = ["centos7", "opensuse423", "sles15", "sles15sp1", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default = ["centos7", "opensuse423", "opensuse150", "sles15", "sles15sp1", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
   type = "list"
 }

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -62,7 +62,7 @@ variable "connect_to_additional_network" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: opensuse423, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
+  description = "One of: opensuse423, opensuse150, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -8,7 +8,7 @@ variable "images" {
     "3.2-nightly" = "sles12sp4"
     "head" = "sles15sp1"
     "test" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse150"
   }
 }
 

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -9,7 +9,7 @@ variable "name" {
 }
 
 variable "product_version" {
-  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, head, test"
+  description = "One of: 3.0-nightly, 3.0-released, 3.1-released, 3.1-nightly, 3.2-nightly, 3.2-released, head, test, uyuni-released"
   type = "string"
 }
 

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -7,7 +7,7 @@ variable "images" {
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "head" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse150"
   }
 }
 

--- a/modules/openstack/base/main.tf
+++ b/modules/openstack/base/main.tf
@@ -24,6 +24,17 @@ resource "openstack_images_image_v2" "opensuse423_image" {
   }
 }
 
+resource "openstack_images_image_v2" "opensuse150_image" {
+  name = "${var.name_prefix}opensuse423"
+  image_source_url = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/openstack/images/opensuse150.x86_64.qcow2"
+  count = "${var.use_shared_resources ? 0 : (contains(var.images, "opensuse150") ? 1 : 0)}"
+  container_format = "bare"
+  disk_format = "qcow2"
+  properties {
+    hw_rng_model = "virtio"
+  }
+}
+
 resource "openstack_images_image_v2" "sles15_image" {
   name = "${var.name_prefix}sles15"
   image_source_url = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles15.x86_64.qcow2"
@@ -155,6 +166,7 @@ output "configuration" {
     // Provider-specific variables
     centos7_image_id = "${join(",", openstack_images_image_v2.centos7_image.*.id)}"
     opensuse423_image_id = "${join(",", openstack_images_image_v2.opensuse423_image.*.id)}"
+    opensuse150_image_id = "${join(",", openstack_images_image_v2.opensuse150_image.*.id)}"
     sles15_image_id = "${join(",", openstack_images_image_v2.sles15_image.*.id)}"
     sles11sp4_image_id = "${join(",", openstack_images_image_v2.sles11sp4_image.*.id)}"
     sles12_image_id = "${join(",", openstack_images_image_v2.sles12_image.*.id)}"

--- a/modules/openstack/base/variables.tf
+++ b/modules/openstack/base/variables.tf
@@ -52,6 +52,6 @@ variable "testsuite" {
 
 variable "images" {
   description = "list of images to be uploaded to Glance, leave default for all"
-  default = ["centos7", "opensuse423",  "sles15",  "sles11sp4",  "sles12", "sles12sp1", "sles12sp2", "sles12sp3"]
+  default = ["centos7", "opensuse423", "opensuse150", "sles15",  "sles11sp4",  "sles12", "sles12sp1", "sles12sp2", "sles12sp3"]
   type = "list"
 }

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -52,7 +52,7 @@ variable "gpg_keys" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: opensuse423, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
+  description = "One of: opensuse423, opensuse150, sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
   type = "string"
 }
 

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -8,7 +8,7 @@ variable "images" {
     "3.2-nightly" = "sles12sp4"
     "head" = "sles15sp1"
     "test" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse150"
   }
 }
 

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -7,7 +7,7 @@ variable "images" {
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
     "head" = "sles15sp1"
-    "uyuni-released" = "opensuse423"
+    "uyuni-released" = "opensuse150"
   }
 }
 

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -110,7 +110,7 @@ http:
     archs: [x86_64]
 
   # SUSE Manager Head Proxy (SLE12-SP4)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
     archs: [x86_64]
 
   # SUSE Manager 3.0 devel

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -167,6 +167,11 @@ http:
   - url: http://download.opensuse.org/update/leap/42.3/oss
     archs: [x86_64]
 
+  - url: http://download.opensuse.org/distribution/leap/15.0/repo/oss
+    archs: [x86_64]
+  - url: http://download.opensuse.org/update/leap/15.0/oss
+    archs: [x86_64]
+
   # SUSE Manager TEST devel
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/TEST/SLE_15_SP1
     archs: [x86_64]

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -196,13 +196,13 @@ http:
     archs: [x86_64]
 
   # Uyuni Master
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_42.3/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/
     archs: [x86_64]
 
   # Uyuni Server
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
     archs: [x86_64]
 
   # Uyuni Proxy
-  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
     archs: [x86_64]

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -213,3 +213,16 @@ http:
   # Uyuni Proxy
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
     archs: [x86_64]
+
+  # TODO: to be enabled when Uyuni on Leap 15.0 is released
+  # # Uyuni Stable
+  # - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.0/
+  #   archs: [x86_64]
+
+  # # Uyuni Server
+  # - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images-openSUSE_Leap_15.0/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+  #   archs: [x86_64]
+
+  # # Uyuni Proxy
+  # - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images-openSUSE_Leap_15.0/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+  #   archs: [x86_64]

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -110,7 +110,7 @@ http:
     archs: [x86_64]
 
   # SUSE Manager Head Proxy (SLE12-SP4)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
     archs: [x86_64]
 
   # SUSE Manager 3.0 devel

--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -190,6 +190,8 @@ http:
     archs: [x86_64]
   - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_42.3
     archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.0
+    archs: [x86_64]
 
   # security:logging (filebeat)
   - url: http://download.opensuse.org/repositories/security:/logging/SLE_12_SP4

--- a/salt/repos/default.sls
+++ b/salt/repos/default.sls
@@ -12,21 +12,19 @@ install_{{ keypath }}:
 {% endfor %}
 
 {% if grains['os'] == 'SUSE' %}
-
-{% if grains['osrelease'] == '42.3' %}
+{% if grains['osfullname'] == 'Leap' %}
 os_pool_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/openSUSE-Leap-42.3-Pool.repo
-    - source: salt://repos/repos.d/openSUSE-Leap-42.3-Pool.repo
+    - name: /etc/zypp/repos.d/openSUSE-Leap-{{ grains['osrelease'] }}-Pool.repo
+    - source: salt://repos/repos.d/openSUSE-Leap-Pool.repo
     - template: jinja
 
 os_update_repo:
   file.managed:
-    - name: /etc/zypp/repos.d/openSUSE-Leap-42.3-Update.repo
-    - source: salt://repos/repos.d/openSUSE-Leap-42.3-Update.repo
+    - name: /etc/zypp/repos.d/openSUSE-Leap-{{ grains['osrelease'] }}-Update.repo
+    - source: salt://repos/repos.d/openSUSE-Leap-Update.repo
     - template: jinja
-{% endif %} {# grains['osrelease'] == '42.3' #}
-
+{% elif grains['osfullname'] == 'SLES' %}
 
 {% if grains['osrelease'] == '11.4' %}
 
@@ -294,7 +292,7 @@ os_update_repo:
     - template: jinja
 {% endif %} {# '15.1' == grains['osrelease'] #}
 
-
+{% endif %} {# grains['osfullname'] == 'SLES' #}
 
 allow_vendor_changes:
   {% if grains['osfullname'] == 'Leap' %}

--- a/salt/repos/repos.d/Uyuni-Master-x86_64-Pool.repo
+++ b/salt/repos/repos.d/Uyuni-Master-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=Uyuni-Master-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
 priority=97

--- a/salt/repos/repos.d/Uyuni-Proxy-Master-x86_64-Pool.repo
+++ b/salt/repos/repos.d/Uyuni-Proxy-Master-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=Uyuni-Proxy-Master-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_42.3/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
 priority=97

--- a/salt/repos/repos.d/openSUSE-Leap-42.3-Pool.repo
+++ b/salt/repos/repos.d/openSUSE-Leap-42.3-Pool.repo
@@ -1,6 +1,0 @@
-[openSUSE-Leap-42.3-Pool]
-name=openSUSE-Leap-42.3-Pool
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/distribution/leap/42.3/repo/oss/suse/
-type=rpm-md
-keeppackages=0

--- a/salt/repos/repos.d/openSUSE-Leap-42.3-Update.repo
+++ b/salt/repos/repos.d/openSUSE-Leap-42.3-Update.repo
@@ -1,5 +1,0 @@
-[openSUSE-Leap-42.3-Update]
-name=openSUSE-Leap-42.3-Update
-enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/42.3/oss/
-type=rpm-md

--- a/salt/repos/repos.d/openSUSE-Leap-Pool.repo
+++ b/salt/repos/repos.d/openSUSE-Leap-Pool.repo
@@ -1,0 +1,10 @@
+[openSUSE-Leap-{{ grains['osrelease'] }}-Pool]
+name=openSUSE-Leap-{{ grains['osrelease'] }}-Pool
+enabled=1
+{% if grains['osrelease'].startswith('42.') %}
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/distribution/leap/{{ grains['osrelease'] }}/repo/oss/suse/
+{% elif grains['osrelease'].startswith('15.') %}
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/distribution/leap/{{ grains['osrelease'] }}/repo/oss/
+{% endif %}
+type=rpm-md
+keeppackages=0

--- a/salt/repos/repos.d/openSUSE-Leap-Update.repo
+++ b/salt/repos/repos.d/openSUSE-Leap-Update.repo
@@ -1,0 +1,5 @@
+[openSUSE-Leap-{{ grains['osrelease'] }}-Update]
+name=openSUSE-Leap-{{ grains['osrelease'] }}-Update
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/update/leap/{{ grains['osrelease'] }}/oss/
+type=rpm-md

--- a/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
+++ b/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
@@ -16,10 +16,10 @@ type=rpm-md
 {% set path = 'SLE_12_SP4' %}
 {% elif grains['osrelease'] == '15.1' %}
 {% set path = 'SLE_15_SP1' %}
-{% elif grains['osrelease'] == '42.3' %}
-{% set path = 'openSUSE_Leap_42.3' %}
-{% elif grains['osrelease'] == '15.0' %}
-{% set path = 'openSUSE_Leap_15.0' %}
+{% endif %}
+
+{% if grains['osfullname'] == 'Leap' %}
+  {% set path = openSUSE_Leap_{{ grains['osrelease'] }} %}
 {% endif %}
 
 baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/sumaform:/tools/{{path}}/

--- a/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
+++ b/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
@@ -18,6 +18,8 @@ type=rpm-md
 {% set path = 'SLE_15_SP1' %}
 {% elif grains['osrelease'] == '42.3' %}
 {% set path = 'openSUSE_Leap_42.3' %}
+{% elif grains['osrelease'] == '15.0' %}
+{% set path = 'openSUSE_Leap_15.0' %}
 {% endif %}
 
 baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/sumaform:/tools/{{path}}/

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Master.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Master.repo
@@ -1,6 +1,6 @@
 [systemsmanagement_Uyuni_Master]
 name=Uyuni builds from master branch
 type=rpm-md
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_42.3/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/
 enabled=1
 priority=96

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
@@ -1,6 +1,6 @@
 [systemsmanagement_Uyuni_Stable]
 name=Uyuni builds from Stable Project
 type=rpm-md
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_42.3/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.0/
 enabled=1
 priority=96


### PR DESCRIPTION
Uyuni is now building for OpenSUSE 15.0 only.

This PR:

- adds OpenSUSE 15.0 to base images for libvirt and OpenStack
- switches Uyuni to use OpenSUSE 15.0 as the base OS
- adds OpenSUSE 15.0 repositories containing Uyuni
- mirror repositories as per the previous point in case you are using a mirror

**Test needed**