### PR TITLE
Switch head to SUSE Manager 4.0 based on SLE15 SP1

### DIFF
--- a/modules/libvirt/base/main.tf
+++ b/modules/libvirt/base/main.tf
@@ -23,6 +23,13 @@ resource "libvirt_volume" "sles15_volume" {
   pool = "${var.pool}"
 }
 
+resource "libvirt_volume" "sles15sp1_volume" {
+  name = "${var.name_prefix}sles15sp1"
+  source = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles15sp1.x86_64.qcow2"
+  count = "${var.use_shared_resources ? 0 : (contains(var.images, "sles15sp1") ? 1 : 0)}"
+  pool = "${var.pool}"
+}
+
 resource "libvirt_volume" "sles11sp4_volume" {
   name = "${var.name_prefix}sles11sp4"
   source = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images/images/sles11sp4.x86_64.qcow2"
@@ -85,6 +92,7 @@ output "configuration" {
     "libvirt_volume.centos7_volume",
     "libvirt_volume.opensuse423_volume",
     "libvirt_volume.sles15_volume",
+    "libvirt_volume.sles15sp1_volume",
     "libvirt_volume.sles11sp4_volume",
     "libvirt_volume.sles12_volume",
     "libvirt_volume.sles12sp1_volume",

--- a/modules/libvirt/base/variables.tf
+++ b/modules/libvirt/base/variables.tf
@@ -72,6 +72,6 @@ variable "bridge" {
 
 variable "images" {
   description = "list of images to be uploaded to the libvirt host, leave default for all"
-  default = ["centos7", "opensuse423", "sles15", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
+  default = ["centos7", "opensuse423", "sles15", "sles15sp1", "sles11sp4", "sles12", "sles12sp1", "sles12sp2", "sles12sp3", "sles12sp4", "ubuntu1804"]
   type = "list"
 }

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -6,7 +6,7 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
-    "head" = "sles12sp4"
+    "head" = "sles15sp1"
     "uyuni-released" = "opensuse423"
   }
 }

--- a/modules/openstack/base/main.tf
+++ b/modules/openstack/base/main.tf
@@ -35,6 +35,17 @@ resource "openstack_images_image_v2" "sles15_image" {
   }
 }
 
+resource "openstack_images_image_v2" "sles15sp1_image" {
+  name = "${var.name_prefix}sles15sp1"
+  image_source_url = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles15sp1.x86_64.qcow2"
+  count = "${var.use_shared_resources ? 0 : (contains(var.images, "sles15sp1") ? 1 : 0)}"
+  container_format = "bare"
+  disk_format = "qcow2"
+  properties {
+    hw_rng_model = "virtio"
+  }
+}
+
 resource "openstack_images_image_v2" "sles11sp4_image" {
   name = "${var.name_prefix}sles11sp4"
   image_source_url = "http://download.suse.de/ibs/Devel:/Galaxy:/Terraform:/Images:/OpenStack/images/sles11sp4.x86_64.qcow2"

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -6,8 +6,8 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
-    "head" = "sles12sp4"
-    "test" = "sles12sp4"
+    "head" = "sles15sp1"
+    "test" = "sles15sp1"
     "uyuni-released" = "opensuse423"
   }
 }

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -6,7 +6,7 @@ variable "images" {
     "3.1-nightly" = "sles12sp4"
     "3.2-released" = "sles12sp4"
     "3.2-nightly" = "sles12sp4"
-    "head" = "sles12sp4"
+    "head" = "sles15sp1"
     "uyuni-released" = "opensuse423"
   }
 }

--- a/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
+++ b/salt/repos/repos.d/systemsmanagement-sumaform-tools.repo
@@ -14,6 +14,8 @@ type=rpm-md
 {% set path = 'SLE_12_SP3' %}
 {% elif grains['osrelease'] == '12.4' %}
 {% set path = 'SLE_12_SP4' %}
+{% elif grains['osrelease'] == '15.1' %}
+{% set path = 'SLE_15_SP1' %}
 {% elif grains['osrelease'] == '42.3' %}
 {% set path = 'openSUSE_Leap_42.3' %}
 {% endif %}

--- a/salt/repos/suse_manager_proxy.sls
+++ b/salt/repos/suse_manager_proxy.sls
@@ -72,6 +72,21 @@ suse_manager_devel_repo:
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_Head.repo
     {% endif %}
     - template: jinja
+
+{% if grains['osfullname'] != 'Leap' %}
+module_server_applications_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_server_applications_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+
+{% endif %}
 {% endif %}
 
 {% if '3.0-nightly' in grains['product_version'] %}

--- a/salt/repos/suse_manager_server.sls
+++ b/salt/repos/suse_manager_server.sls
@@ -72,6 +72,38 @@ suse_manager_devel_repo:
     - source: salt://repos/repos.d/Devel_Galaxy_Manager_Head.repo
     {% endif %}
     - template: jinja
+
+{% if grains['osfullname'] != 'Leap' %}
+module_server_applications_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_server_applications_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+
+module_web_scripting_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Web_Scripting_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+
+module_web_scripting_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Web_Scripting_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Update.repo
+    - template: jinja
+
+module_python2_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Python2_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
+    - template: jinja
+{% endif %}
 {% endif %}
 
 {% if '3.0-nightly' in grains['product_version'] %}

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -13,7 +13,11 @@ proxy-packages:
       {% else %}
       - patterns-suma_proxy
       {% endif %}
+{% if grains.get('osmajorrelease', None)|int() == 15 %}
+      - firewalld
+{% else %}
       - SuSEfirewall2
+{% endif %}
     - require:
       - sls: repos
 


### PR DESCRIPTION
add the missing pieces to install SUSE Manager 4.0 (head) with SLE 15 SP1.

- add  image definition
- sumaform tools for SLE15 SP1
- Module repository definitions required for SUSE Manager
- change defaults for head
- fix firewall package