### PR TITLE
Adapt tomcat JDWP options

### DIFF
--- a/salt/suse_manager_server/tomcat.sls
+++ b/salt/suse_manager_server/tomcat.sls
@@ -12,9 +12,9 @@ tomcat_config:
     {% endif %}
     - pattern: 'JAVA_OPTS="(?!-Xdebug)(.*)"'
     {% if grains['hostname'] and grains['domain'] %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }} \1"'
+    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['hostname'] }}.{{ grains['domain'] }} \1"'
     {% else %}
-    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }} \1"'
+    - repl: 'JAVA_OPTS="-Xdebug -Xrunjdwp:transport=dt_socket,address=*:8000,server=y,suspend=n -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdn'] }} \1"'
     {% endif %}
     - require:
       - sls: suse_manager_server.rhn


### PR DESCRIPTION
Since Tomcat 8, the JDWP '8000' address binds to localhost by default. See

    http://tomcat.apache.org/migration-8.html#Debugging

We now need '*:8000' address to be able to remote debug tomcat.