### PR TITLE
SUSE Manager 4 become a base product - use the modules in sumaform

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -105,20 +105,12 @@ http:
   #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15:/x86_64/update
   #  #  archs: [x86_64]
 
-  # SUSE Manager Head (SLE12-SP4)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-4.0-POOL-x86_64-Media1
+  # SUSE Manager Head (SLE15-SP1)
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-4.0-POOL-x86_64-Media1
     archs: [x86_64]
 
   # SUSE Manager Head Proxy (SLE12-SP4)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
-    archs: [x86_64]
-
-  # SUSE Manager Head (openSUSE Leap 42.3)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE42.3-SUSE-Manager-Server-4.0-POOL-x86_64-Media1
-    archs: [x86_64]
-
-  # SUSE Manager Head Proxy (openSUSE Leap 42.3)
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images-openSUSE_Leap_42.3/repo/openSUSE42.3-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1
     archs: [x86_64]
 
   # SUSE Manager 3.0 devel

--- a/salt/repos/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Head-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=SUSE-Manager-Head-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Server-4.0-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-4.0-POOL-x86_64-Media1/
 priority=97

--- a/salt/repos/repos.d/SUSE-Manager-Proxy-Head-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SUSE-Manager-Proxy-Head-x86_64-Pool.repo
@@ -2,5 +2,5 @@
 name=SUSE-Manager-Proxy-Head-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Proxy-4.0-POOL-x86_64-Media1/
 priority=97


### PR DESCRIPTION
SUSE Manager will change to be a base product.
The old name is now used for the root product and we have a new name for the module which
contains the packages.
Change to use the new module in sumaform.