### PR TITLE
Enable additional disk definitions on server too

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -73,6 +73,7 @@ EOF
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  additional_disk = "${var.additional_disk}"
 }
 
 output "configuration" {

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -227,3 +227,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default = ""
 }
+
+variable "additional_disk" {
+  description = "disk block definition(s) to be added to this host"
+  default = []
+}


### PR DESCRIPTION
This PR makes it possible to use additional disks on the suse manager server too. Currently it's only possible on "hosts" (aka suse manager clients).

Syntax is strictly identical to the one for hosts, i.e. you pass a list of volume ids to the `suse_manager` module:
```
  additional_disk = [ {
    volume_id = "${element(libvirt_volume.packages_disk.*.id, 1)}"
  } ]
```
and you define the extra resources like this:
```
resource "libvirt_volume" "packages_disk" {
  name = "ebi2-packages-disk"
  base_volume_name = "empty_disk.qcow2"
  pool = "default"
  count = 1
}
```

NOTE: I wanted a more ambitious pull request, that would also do the following:
 * define the disk resource for the packages
 * modify `/etc/fstab` to define a mount point for `/var/spacewalk`
 * do the mount
 * possibly reduce the size of the server's main disk
   (200 GiB becomes too much once you have this)

HOWEVER I don't have the time to write it right now, and even with that more ambitious PR, the current PR could remain useful. It's simple and compatible with the rest of sumaform, so I suggest we start with this less ambitious PR.
