### PR TITLE
monitor the salt event log when running the testsuite

### DIFF
--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -155,7 +155,11 @@ tomcat:
       - file: enable_salt_content_staging_advance
 
 dump_salt_event_log:
-  cmd.run:
-    - name: nohup salt-run state.event pretty=True > /var/log/rhn/salt-event.log &
+    cmd.run:
+        - name: |-
+            exec 0>&- # close stdin
+            exec 1>&- # close stdout
+            exec 2>&- # close stderr
+            nohup salt-run state.event pretty=True > /var/log/rhn/salt-event.log &
 
 {% endif %}

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -154,4 +154,8 @@ tomcat:
       - file: enable_salt_content_staging_window
       - file: enable_salt_content_staging_advance
 
+dump_salt_event_log:
+  cmd.run:
+    - name: nohup salt-run state.event pretty=True > /var/log/rhn/salt-event.log &
+
 {% endif %}


### PR DESCRIPTION
When we monitor the whole event log we can easier see why errors happens in the testsuite.

