### PR TITLE
Use SLE 12 SP4 to build test packages

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -177,7 +177,7 @@ http:
     archs: [x86_64]
 
   # Testsuite dummy packages for testing repo
-  - url: http://download.suse.de/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1
+  - url: http://download.suse.de/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP4
     archs: [x86_64]
 
   # Software for sumaformed Virtual Machines

--- a/salt/repos/repos.d/Devel_Galaxy_BuildRepo.repo
+++ b/salt/repos/repos.d/Devel_Galaxy_BuildRepo.repo
@@ -1,5 +1,5 @@
 [Devel_Galaxy_BuildRepo]
-name=Repo with new RPMs used for Testsuite (SLE_12_SP1)
+name=Repo with new RPMs used for Testsuite (SLE_12_SP4)
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP1/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de", true) }}/ibs/Devel:/Galaxy:/BuildRepo/SLE_12_SP4/

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -62,7 +62,7 @@ test_repo:
     - name: minima sync
     - env:
       - MINIMA_CONFIG: |
-          - url: http://download.suse.de/ibs/Devel:/Galaxy:/TestsuiteRepo/SLE_12_SP1
+          - url: http://download.suse.de/ibs/Devel:/Galaxy:/TestsuiteRepo/SLE_12_SP4
             path: /srv/www/htdocs/pub/TestRepo
     - require:
       - archive: minima


### PR DESCRIPTION
Use SLE 12 SP4 instead of SLE 12 SP1 for the test packages (`andromeda-dummy` and friends).

The new packages are already built at https://build.suse.de/project/show/Devel:Galaxy:TestsuiteRepo and https://download.suse.de/ibs/Devel:/Galaxy:/BuildRepo/ .

(long story made short: I need them anyway for the new suite, so let's upgrade)
