### PR TITLE
Released versions for 3.1 and 3.2 are based only on SP3

### DIFF
--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -2,9 +2,9 @@ variable "images" {
   default = {
     "3.0-released" = "sles12sp1"
     "3.0-nightly" = "sles12sp1"
-    "3.1-released" = "sles12sp4"
-    "3.1-nightly" = "sles12sp4"
-    "3.2-released" = "sles12sp4"
+    "3.1-released" = "sles12sp3"
+    "3.1-nightly" = "sles12sp3"
+    "3.2-released" = "sles12sp3"
     "3.2-nightly" = "sles12sp4"
     "head" = "sles15sp1"
     "test" = "sles15sp1"


### PR DESCRIPTION
Released versions for 3.1 and 3.2 are based only on SP3 for 3.1-nightly it will never be SP4 it's EOL.