### PR TITLE
Open ipmi for testsuite

### DIFF
--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -108,18 +108,15 @@ cobbler_configuration:
     - require:
       - sls: suse_manager_server
 
-expect:
-  pkg.installed
-
-aaa_base-extras:
-  pkg.installed
-
-salt-ssh:
+testsuite_packages:
   pkg.installed:
+    - pkgs:
+      - expect
+      - aaa_base-extras
+      - salt-ssh
+      - wget
     - require:
       - sls: repos
-wget:
-  pkg.installed
 
 enable_salt_content_staging_window:
   file.replace:

--- a/salt/suse_manager_server/testsuite.sls
+++ b/salt/suse_manager_server/testsuite.sls
@@ -115,6 +115,7 @@ testsuite_packages:
       - aaa_base-extras
       - salt-ssh
       - wget
+      - OpenIPMI
     - require:
       - sls: repos
 


### PR DESCRIPTION
OpenIPMI package is required for our tests. In SLE12 it was a dependency of

  cobbler -> ipmitool -> OpenIPMI

and installed via cobbler.
In SLE15 ipmitool does not have this dependency anymore. This cause our IPMI tests to fail.


Additionally combine multiple pkg.installed into one to safe time