### PR TITLE
Revert "use newer chromedriver version"

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -60,12 +60,12 @@ cucumber_requisites:
 chromium_fixed_version:
   pkg.installed:
   - name: chromium
-  - version: 72.0.3626.96
+  - version: 64.0.3282.167
 
 chromedriver_fixed_version:
   pkg.installed:
   - name: chromedriver
-  - version: 72.0.3626.96
+  - version: 64.0.3282.167
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
The newer driver version 72 has memory leaks and is a lot slower
Use the old one as long as we do not need a newer driver because
of other reasons

This reverts commit f23a0763b2780ef5818273d89a13e030e20359cb.