### PR TITLE
Try version 73 of chromium and chromedriver

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -60,12 +60,12 @@ cucumber_requisites:
 chromium_fixed_version:
   pkg.installed:
   - name: chromium
-  - version: 64.0.3282.167
+  - version: 73.0.3683.75
 
 chromedriver_fixed_version:
   pkg.installed:
   - name: chromedriver
-  - version: 64.0.3282.167
+  - version: 73.0.3683.75
 
 create_syslink_for_chromedriver:
   file.symlink:


### PR DESCRIPTION
First tests show that version 73  of chromium and chromedriver behaves more or less in terms of memory usage.

This PR will run during the night to evaluate if it also behaves more or less fine in terms of run time.

If it does, it will stay. If not, it will be reverted.

