### PR TITLE
WIP: Add SLE-15-SP1 moving target (valid until GM is ready)

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -105,6 +105,16 @@ http:
   #- url: http://download.suse.de/ibs/SUSE:/Maintenance:/Test:/SLE-Module-Basesystem:/15:/x86_64/update
   #  #  archs: [x86_64]
 
+  # SLE 15 SP1 moving target (valid until GM)
+  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Basesystem-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Python2-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Server-Applications-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Web-Scripting-POOL-x86_64-Media1/
+    archs: [x86_64]
+
   # SUSE Manager Head (SLE15-SP1)
   - url: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head/images/repo/SLE-Module-SUSE-Manager-Server-4.0-POOL-x86_64-Media1
     archs: [x86_64]

--- a/salt/repos/repos.d/SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-15-SP1-x86_64-Pool.repo
@@ -2,4 +2,5 @@
 name=SLE-Module-Basesystem15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
+#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Basesystem/15-SP1/x86_64/product/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Basesystem-POOL-x86_64-Media1/

--- a/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Python2-SLE-15-SP1-x86_64-Pool.repo
@@ -2,4 +2,5 @@
 name=SLE-Module-Python2-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
+#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Python2/15-SP1/x86_64/product/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Python2-POOL-x86_64-Media1/

--- a/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool.repo
@@ -2,4 +2,5 @@
 name=SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/
+#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15-SP1/x86_64/product/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Server-Applications-POOL-x86_64-Media1/

--- a/salt/repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool.repo
@@ -2,4 +2,5 @@
 name=SLE-Module-Web-Scripting-SLE-15-SP1-x86_64-Pool
 type=rpm-md
 enabled=1
-baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/
+#baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Web-Scripting/15-SP1/x86_64/product/
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE:/SLE-15-SP1:/GA:/TEST/images/repo/SLE-15-SP1-Module-Web-Scripting-POOL-x86_64-Media1/


### PR DESCRIPTION
As otherwise the image for SLE-15-SP1 was using the moving target and installing a newer build of salt (1.7) therefore braking sumaform installation as it was using RC1 (1.1).

This workaround will go away with SLE-15-SP1 GM is out.