### PR TITLE
Let hosts be able to use additional swap files

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -102,7 +102,7 @@ By default, sumaform deploys hosts with a range of tweaked settings for convenie
    * `auto_register`: automatically registers clients to the SUSE Manager Server. Set to `false` for manual registration
  * `minion` module:
    * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure
- * `proxy` module:
+ * `suse_manager_proxy` module:
    * `minion`: whether to configure this Proxy as a Salt minion. Set to `false` to have the Proxy set up as a traditional client
    * `auto_connect_to_master`: automatically connects to the Salt Master. Set to `false` to manually configure. Requires `minion` to be `true`
    * `auto_register`: automatically registers the proxy to its upstream Server or Proxy. Defaults to `false`, requires `minion` to be `false`
@@ -333,7 +333,9 @@ Please note that `iss_master` is set from `master`'s module output variable `hos
 
 Also note that this requires `create_first_user` and `publish_private_ssl_key` settings to be true (they are by default).
 
+
 ## Performance testsuite
+
 It is possible to run the Performance testsuite for SUSE Manager by defining a "pts" module. This will create a test server, a locust load server, an minion instance with evil-minions running on it and (by default) a grafana host to monitor them.
 
 A libvirt example follows:
@@ -734,7 +736,7 @@ With the default configuration, whenever SUSE Manager server hosts are configure
 
 This setting can be overridden with a custom 'from' address by supplying the parameter: `from_email`. A libvirt example would be:
 
-```
+```hcl
 module "suma3pg" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
@@ -749,7 +751,7 @@ module "suma3pg" {
 Internal Server Errors and relative stacktraces are sent via e-mail by default to `galaxy-noise@suse.de`.
 By suppling the parameter `traceback_email` you can override that address to have them in your inbox:
 
-```
+```hcl
 module "sumamail3" {
   source = "./modules/libvirt/suse_manager"
   base_configuration = "${module.base.configuration}"
@@ -760,3 +762,23 @@ module "sumamail3" {
   traceback_email = "michele.bologna@chameleon-mail.com"
 }
 ```
+
+
+# Swap file configuration
+
+You can add a swap file to most hosts, to prevent out-of-memory conditions.
+
+Please note that some systems already come with some swap file or swap partition of their own: Ubuntu and CentOS minions, and
+SUSE Manager server.
+
+A libvirt example is:
+
+```hcl
+module "minion" {
+   ...
+   swap_file_size = 2048 // in MiB
+   ...
+}
+```
+
+To disable the swap file, set its size to 0.

--- a/modules/libvirt/client/main.tf
+++ b/modules/libvirt/client/main.tf
@@ -9,6 +9,7 @@ module "client" {
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   connect_to_base_network = true
   connect_to_additional_network = true

--- a/modules/libvirt/client/variables.tf
+++ b/modules/libvirt/client/variables.tf
@@ -48,6 +48,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -19,6 +19,7 @@ module "controller" {
   name = "${var.name}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   connect_to_base_network = true
   connect_to_additional_network = false

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -94,6 +94,10 @@ variable "additional_packages" {
   default = []
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 4096
+}
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/host/main.tf
+++ b/modules/libvirt/host/main.tf
@@ -87,8 +87,9 @@ use_os_released_updates: ${var.use_os_released_updates}
 use_os_unreleased_updates: ${var.use_os_unreleased_updates}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
+swap_file_size: ${var.swap_file_size}
 authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
-gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
+gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 connect_to_base_network: ${var.connect_to_base_network}
 connect_to_additional_network: ${var.connect_to_additional_network}
 reset_ids: true

--- a/modules/libvirt/host/variables.tf
+++ b/modules/libvirt/host/variables.tf
@@ -38,6 +38,11 @@ variable "grains" {
   default = ""
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -9,6 +9,7 @@ module "minion" {
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   connect_to_base_network = true
   connect_to_additional_network = true

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -68,6 +68,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/minionswarm/main.tf
+++ b/modules/libvirt/minionswarm/main.tf
@@ -6,6 +6,7 @@ module "minionswarm" {
   count = "${var.count}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
@@ -15,7 +16,6 @@ server: ${var.server_configuration["hostname"]}
 role: minionswarm
 minion_count: ${var.minion_count}
 start_delay: ${var.start_delay}
-swap_file_size: ${var.swap_file_size}
 
 EOF
 

--- a/modules/libvirt/minionswarm/variables.tf
+++ b/modules/libvirt/minionswarm/variables.tf
@@ -39,7 +39,7 @@ variable "count"  {
 }
 
 variable "swap_file_size" {
-  description = "Swap file size in MiB"
+  description = "Swap file size in MiB, or 0 for none"
   default = 8192
 }
 

--- a/modules/libvirt/mirror/main.tf
+++ b/modules/libvirt/mirror/main.tf
@@ -14,6 +14,7 @@ module "mirror" {
   name = "mirror"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/libvirt/mirror/variables.tf
+++ b/modules/libvirt/mirror/variables.tf
@@ -13,6 +13,11 @@ variable "additional_packages" {
   default = []
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/suse_manager/main.tf
+++ b/modules/libvirt/suse_manager/main.tf
@@ -22,6 +22,7 @@ module "suse_manager" {
   use_os_unreleased_updates = "${var.use_os_unreleased_updates}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   connect_to_base_network = true

--- a/modules/libvirt/suse_manager/variables.tf
+++ b/modules/libvirt/suse_manager/variables.tf
@@ -165,6 +165,11 @@ variable "traceback_email" {
   default = "null"
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/libvirt/suse_manager_proxy/main.tf
+++ b/modules/libvirt/suse_manager_proxy/main.tf
@@ -21,6 +21,7 @@ module "suse_manager_proxy" {
   use_os_unreleased_updates = "${var.use_os_unreleased_updates}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   connect_to_base_network = true

--- a/modules/libvirt/suse_manager_proxy/variables.tf
+++ b/modules/libvirt/suse_manager_proxy/variables.tf
@@ -83,6 +83,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/client/main.tf
+++ b/modules/openstack/client/main.tf
@@ -9,6 +9,7 @@ module "client" {
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/openstack/client/variables.tf
+++ b/modules/openstack/client/variables.tf
@@ -48,6 +48,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -19,6 +19,7 @@ module "controller" {
   name = "${var.name}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -86,6 +86,11 @@ variable "additional_packages" {
   default = []
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 4096
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/host/main.tf
+++ b/modules/openstack/host/main.tf
@@ -107,8 +107,9 @@ use_os_released_updates: ${var.use_os_released_updates}
 use_os_unreleased_updates: ${var.use_os_unreleased_updates}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
+swap_file_size: ${var.swap_file_size}
 authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
-gpg_keys:  [${join(", ", formatlist("'%s'", var.gpg_keys))}]
+gpg_keys: [${join(", ", formatlist("'%s'", var.gpg_keys))}]
 reset_ids: true
 ${var.grains}
 

--- a/modules/openstack/host/variables.tf
+++ b/modules/openstack/host/variables.tf
@@ -38,6 +38,11 @@ variable "grains" {
   default = ""
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/minion/main.tf
+++ b/modules/openstack/minion/main.tf
@@ -9,6 +9,7 @@ module "minion" {
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -68,6 +68,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/minionswarm/main.tf
+++ b/modules/openstack/minionswarm/main.tf
@@ -6,6 +6,7 @@ module "minionswarm" {
   count = "${var.count}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 
@@ -15,7 +16,6 @@ server: ${var.server_configuration["hostname"]}
 role: minionswarm
 minion_count: ${var.minion_count}
 start_delay: ${var.start_delay}
-swap_file_size: ${var.swap_file_size}
 
 EOF
 

--- a/modules/openstack/minionswarm/variables.tf
+++ b/modules/openstack/minionswarm/variables.tf
@@ -39,7 +39,7 @@ variable "count"  {
 }
 
 variable "swap_file_size" {
-  description = "Swap file size in MiB"
+  description = "Swap file size in MiB, or 0 for none"
   default = 8192
 }
 

--- a/modules/openstack/mirror/main.tf
+++ b/modules/openstack/mirror/main.tf
@@ -5,6 +5,7 @@ module "mirror" {
   name = "mirror"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   grains = <<EOF
 

--- a/modules/openstack/mirror/variables.tf
+++ b/modules/openstack/mirror/variables.tf
@@ -13,6 +13,11 @@ variable "additional_packages" {
   default = []
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/suse_manager/main.tf
+++ b/modules/openstack/suse_manager/main.tf
@@ -22,6 +22,7 @@ module "suse_manager" {
   use_os_unreleased_updates = "${var.use_os_unreleased_updates}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   grains = <<EOF

--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -165,6 +165,11 @@ variable "traceback_email" {
   default = "null"
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/modules/openstack/suse_manager_proxy/main.tf
+++ b/modules/openstack/suse_manager_proxy/main.tf
@@ -21,6 +21,7 @@ module "suse_manager_proxy" {
   use_os_unreleased_updates = "${var.use_os_unreleased_updates}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
+  swap_file_size = "${var.swap_file_size}"
   ssh_key_path = "${var.ssh_key_path}"
   gpg_keys = "${var.gpg_keys}"
   grains = <<EOF

--- a/modules/openstack/suse_manager_proxy/variables.tf
+++ b/modules/openstack/suse_manager_proxy/variables.tf
@@ -83,6 +83,11 @@ variable "count"  {
   default = 1
 }
 
+variable "swap_file_size" {
+  description = "Swap file size in MiB, or 0 for none"
+  default = 0
+}
+
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
   default = "/dev/null"

--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -36,6 +36,21 @@ update_packages:
       - sls: repos
 {% endif %}
 
+{% if grains.get('swap_file_size', "0")|int() > 0 %}
+file_swap:
+  cmd.run:
+    - name: |
+        {% if grains['os_family'] == 'RedHat' %}dd if=/dev/zero of=/extra_swapfile bs=1048576 count={{grains['swap_file_size']}}{% else %}fallocate --length {{grains['swap_file_size']}}MiB /extra_swapfile{% endif %}
+        chmod 0600 /extra_swapfile
+        mkswap /extra_swapfile
+    - creates: /extra_swapfile
+  mount.swap:
+    - name: /extra_swapfile
+    - persist: true
+    - require:
+      - cmd: file_swap
+{% endif %}
+
 {% if grains['authorized_keys'] %}
 authorized_keys:
   file.append:

--- a/salt/minionswarm/init.sls
+++ b/salt/minionswarm/init.sls
@@ -1,22 +1,6 @@
 include:
   - repos
 
-{% if grains.has_key('swap_file_size') %}
-file_swap:
-  cmd.run:
-    - name: |
-        fallocate --length {{grains["swap_file_size"]}}MiB /swapfile
-        chmod 0600 /swapfile
-        mkswap /swapfile
-        swapon -a
-    - creates: /swapfile
-  mount.swap:
-    - name: /swapfile
-    - persist: true
-    - require:
-      - cmd: file_swap
-{% endif %}
-
 salt_master:
   pkg.installed:
     - name: salt-master


### PR DESCRIPTION
This PR allows to use a swapfile to complement missing memory at the expense of some slowness.

Most interesting is the test suite controller (as an insurance policy against Selenium becoming crazy), but the others are allowed as well.

Not concerned: the server (SUSE manager will create a swapfile on its own), the mirror.