### PR TITLE
Bugfix: correct Uyuni Stable URLs

### DIFF
--- a/salt/mirror/minima.yaml
+++ b/salt/mirror/minima.yaml
@@ -205,13 +205,17 @@ http:
   # Uyuni Master
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/openSUSE_Leap_15.0/
     archs: [x86_64]
-
-  # Uyuni Server
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
     archs: [x86_64]
-
-  # Uyuni Proxy
   - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master/images-openSUSE_Leap_15.0/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
+    archs: [x86_64]
+
+  # Uyuni Stable
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_42.3/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-4.0-POOL-x86_64-Media1/
+    archs: [x86_64]
+  - url: http://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-4.0-POOL-x86_64-Media1/
     archs: [x86_64]
 
   # TODO: to be enabled when Uyuni on Leap 15.0 is released

--- a/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
+++ b/salt/repos/repos.d/systemsmanagement_Uyuni_Stable.repo
@@ -1,6 +1,6 @@
 [systemsmanagement_Uyuni_Stable]
 name=Uyuni builds from Stable Project
 type=rpm-md
-baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_15.0/
+baseurl=http://{{ grains.get("mirror") | default("download.opensuse.org", true) }}/repositories/systemsmanagement:/Uyuni:/Stable/openSUSE_Leap_42.3/
 enabled=1
 priority=96


### PR DESCRIPTION
Two URLs were not in minima, one is apparently wrong in the .repo file.