### PR TITLE
WORKAROUND while our IPv6 infrastructure is broken

### DIFF
--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -72,12 +72,18 @@ create_syslink_for_chromedriver:
     - name: /usr/bin/chromedriver
     - target: /usr/lib64/chromium/chromedriver
 
+# WORKAROUND - remove when we have a working IPv6 infrastructure
+disable_ipv6:
+  cmd.run:
+    - name: sysctl -w net.ipv6.conf.all.disable_ipv6=1
+
 install_gems_via_bundle:
   cmd.run:
     - name: bundle.ruby2.1 install --gemfile /root/spacewalk/testsuite/Gemfile
     - require:
       - pkg: cucumber_requisites
       - cmd: spacewalk_git_repository
+      - cmd: disable_ipv6     # WORKAROUND - remove when we have a working IPv6 infrastructure
 
 spacewalk_git_repository:
   cmd.run:


### PR DESCRIPTION
Emergency fix as long as we can't reach outside SUSE with IPv6 from mgr.suse.de.

This touches only the test suite controller. Hopefully it's enough. If it's not enough, we will need a proper setting `ipv6 = no` at host level.

To be removed once the infra problems are solved.