### PR TITLE
Bugfix: avoid too old Java versions in Leap 42.3

### DIFF
--- a/salt/suse_manager_server/init.sls
+++ b/salt/suse_manager_server/init.sls
@@ -15,6 +15,14 @@ include:
   - suse_manager_server.salt_master
   - suse_manager_server.apparmor
 
+# HACK: make sure we do not run into a JVM bug in the openSUSE 42.3 outdated package
+{% if grains['osfullname'] == 'Leap' and grains['osrelease'] == '42.3' %}
+java-1_8_0-openjdk-headless:
+  pkg.latest:
+    - require:
+      - sls: repos
+{% endif %}
+
 suse_manager_packages:
   pkg.latest:
     - refresh: True


### PR DESCRIPTION
This prevents a non-working Tomcat after deployment.