### PR TITLE
Mirror: get the new SCC product_tree.json

### DIFF
--- a/salt/mirror/refresh_scc_data.py
+++ b/salt/mirror/refresh_scc_data.py
@@ -56,3 +56,7 @@ print("organizations_subscriptions.json refreshed")
 orders = get_paginated(connection, headers, "/connect/organizations/orders")
 save_json(orders, "organizations_orders.json")
 print("organizations_orders.json refreshed")
+
+product_tree = get_paginated(connection, headers, "/suma/product_tree.json")
+save_json(product_tree, "product_tree.json")
+print("product_tree.json refreshed")


### PR DESCRIPTION
Since commit [cea84f20](https://github.com/uyuni-project/uyuni/commit/cea84f20) SUSE Manager / Uyuni uses a new `product_tree.json` file from SCC. This needs to be mirrored too.