### PR TITLE
Use fqdn instead of 'localhost' as a target for reposync

### DIFF
--- a/salt/suse_manager_server/initial_content.sls
+++ b/salt/suse_manager_server/initial_content.sls
@@ -73,7 +73,7 @@ add_channels:
 reposync_{{ channel }}:
   cmd.script:
     - name: salt://suse_manager_server/wait_for_reposync.py
-    - args: "{{ grains.get('server_username') | default('admin', true) }} {{ grains.get('server_password') | default('admin', true) }} localhost {{ channel }}"
+    - args: "{{ grains.get('server_username') | default('admin', true) }} {{ grains.get('server_password') | default('admin', true) }} {{ grains.get('fqdn') | default('localhost', true) }} {{ channel }}"
     - use_vt: True
     - require:
       - cmd: add_channels


### PR DESCRIPTION
- on SUMA4/Uyuni the SSL validation fails if the 'localhost' is
  used as a destination for reposync check script.
  Using machine fqdn grain to solve this problem.