### PR TITLE
Virtual host improvements

### DIFF
--- a/README_ADVANCED.md
+++ b/README_ADVANCED.md
@@ -730,29 +730,6 @@ module "sumaheadpg" {
 }
 ```
 
-## Virtual hosts
-
-Virtualization host are salt minion hosts that server virtual machines, using KVM hypervisor.
-Note that Xen does not support nested virtualization.
-
-A libvirt example follows:
-
-```hcl
-module "virthost" {
-  source = "./modules/libvirt/virthost"
-  base_configuration = "${module.base.configuration}"
-  ...
-  name = "min-kvm"
-  image = "sles15sp1"
-  ...
-  vcpu = 3
-  memory = 2048
-}
-```
-
-The created virtual host will get it's host CPU model. This means that in order for virtual hosts to host virtual machines, nested virtualization has to be enabled on the physical machine.
-
-
 ## E-mail configuration
 
 With the default configuration, whenever SUSE Manager server hosts are configured to use root@`hostname -d` as the email sender. The recipient's SMTP server may discard those emails since they come from a non-existent domain name.

--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -29,7 +29,7 @@ module "ctl" {
   ubuntu_configuration = "${module.min-ubuntu.configuration}"          // optional
   minionssh_configuration = "${module.minssh-sles12sp3.configuration}" // optional
   pxeboot_configuration = "${module.pxeboot-sles12sp3.configuration}"  // optional
-  kvmhost_configuration = "${module.min-kvm.configuration}"  // optional
+  kvmhost_configuration = "${module.min-kvm.configuration}"            // optional
   branch = "default"
   // credentials available in https://gitlab.suse.de/galaxy/sumaform-test-runner/blob/master/head/main-full.tf
   git_username = ...
@@ -132,4 +132,6 @@ module "min-kvm"
   name = "min-kvm"
   image = "sles15sp1"
   ssh_key_path = "./salt/controller/id_rsa.pub"
+  server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
+  auto_connect_to_master = false
 }

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -28,6 +28,8 @@ susemanager:
 evil_minion_count: ${var.evil_minion_count}
 evil_minion_slowdown_factor: ${var.evil_minion_slowdown_factor}
 
+${var.additional_grains}
+
 EOF
 
   // Provider-specific variables
@@ -36,6 +38,7 @@ EOF
   vcpu = "${var.vcpu}"
   running = "${var.running}"
   mac = "${var.mac}"
+  cpu_model = "${var.cpu_model}"
 }
 
 output "configuration" {

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -84,6 +84,11 @@ variable "gpg_keys" {
   default = []
 }
 
+variable "additional_grains" {
+  description = "custom grain string to be added to this minion's configuration"
+  default = ""
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/modules/libvirt/virthost/main.tf
+++ b/modules/libvirt/virthost/main.tf
@@ -1,19 +1,23 @@
 module "virthost" {
-  source = "../host"
+  source = "../minion"
 
   base_configuration = "${var.base_configuration}"
   name = "${var.name}"
+  product_version = "${var.product_version}"
+  server_configuration = "${var.server_configuration}"
+  activation_key = "${var.activation_key}"
+  auto_connect_to_master = "${var.auto_connect_to_master}"
+  use_os_released_updates = "${var.use_os_released_updates}"
+  use_os_unreleased_updates = "${var.use_os_unreleased_updates}"
+  apparmor = "${var.apparmor}"
   additional_repos = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
   gpg_keys = "${var.gpg_keys}"
   ssh_key_path = "${var.ssh_key_path}"
-  connect_to_base_network = true
-  connect_to_additional_network = true
-  grains = <<EOF
+  additional_grains = <<EOF
 
-mirror: ${var.base_configuration["mirror"]}
 hvm_disk_image: "${var.hvm_disk_image}"
-role: virthost
+virtual_host: true
 EOF
 
   // Provider-specific variables

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -8,9 +8,34 @@ variable "name" {
   type = "string"
 }
 
+variable "product_version" {
+  description = "A valid SUSE Manager version (eg. 3.0-nightly, head) see README_ADVANCED.md"
+  default = "released"
+}
+
+variable "server_configuration" {
+  description = "use ${module.<SERVER_NAME>.configuration}, see the main.tf example file"
+  type = "map"
+}
+
 variable "activation_key" {
   description = "an Activation Key to be used when onboarding this minion"
   default = "null"
+}
+
+variable "auto_connect_to_master" {
+  description = "whether this minion should automatically connect to the Salt Master upon deployment"
+  default = true
+}
+
+variable "use_os_released_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise repos"
+  default = false
+}
+
+variable "use_os_unreleased_updates" {
+  description = "Apply all updates from SUSE Linux Enterprise unreleased (Test) repos"
+  default = false
 }
 
 variable "apparmor" {
@@ -47,7 +72,7 @@ variable "hvm_disk_image" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles11sp4, sles12, sles12sp1, sles12sp2, sles12sp3, sles15, centos7"
+  description = "One of: sles12sp3, sles15, opensuse423 or opensuse150"
   type = "string"
 }
 

--- a/salt/repos/virthost.sls
+++ b/salt/repos/virthost.sls
@@ -1,4 +1,4 @@
-{% if grains.get('role') == 'virthost' %}
+{% if grains.get('virtual_host') | default(false, true) %}
 
 {% if grains['osfullname'] != 'Leap' and '15' in grains['osrelease']  %}
 module_server_applications_pool_repo:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -38,6 +38,6 @@ base:
     - match: grain
     - locust
 
-  'role:virthost':
+  'virtual_host:true':
     - match: grain
     - virthost


### PR DESCRIPTION
Move the virtual host documentation to the libvirt README since this is
not applicable to the clouds.

Also make the virtual host a true salt minion.

Follow up of PR #520 