### PR TITLE
Avoid machine name ending in -2 in case of an avahi reflector

### DIFF
--- a/salt/default/avahi.sls
+++ b/salt/default/avahi.sls
@@ -25,6 +25,22 @@ avahi_restrict_interfaces:
     - require:
       - pkg: avahi_pkg
 
+# work around https://github.com/lathiat/avahi/issues/117 triggered by reflector
+avahi-avoid-name-conflicts:
+  file.replace:
+    - name: /etc/avahi/avahi-daemon.conf
+    - pattern: "use-ipv6=yes"
+    - repl: "use-ipv6=no"
+    - require:
+      - pkg: avahi_pkg
+
+# work around (continued)
+restart-avahi:
+  cmd.run:
+    - name: systemctl restart avahi
+    - require:
+      - file: avahi-avoid-name-conflicts
+
 mdns_declare_domains:
   file.append:
     - name: /etc/mdns.allow


### PR DESCRIPTION
In case there is an avahi reflector on the network, the machine might end up with a name like `hmu-minion-2.tf.local`.

Issue is described here: https://github.com/lathiat/avahi/issues/117

Basically, the machine considers its own avahi probe as coming from a duplicate machine, and adds the `-2` to its own name.