### PR TITLE
Add variable for http proxy

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -41,6 +41,7 @@ pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
+http_proxy: ${var.http_proxy}
 
 EOF
 

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -117,6 +117,11 @@ variable "git_profiles_repo" {
   default = "default"
 }
 
+variable "http_proxy" {
+  description = "Define hostname and port used by SUSE Manager http proxy"
+  default = ""
+}
+
 // Provider-specific variables
 
 variable "memory" {

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -37,6 +37,7 @@ ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
+http_proxy: ${var.http_proxy}
 
 EOF
 

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -24,6 +24,11 @@ variable "git_repo" {
   default = "default"
 }
 
+variable "http_proxy" {
+  description = "Define hostname and port used by SUSE Manager http proxy"
+  default = ""
+}
+
 variable "branch" {
   description = "Leave default for automatic selection or specify an existing branch of spacewalk"
   default = "default"

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -14,6 +14,7 @@ export VIRTHOST_KVM_URL="{{ grains.get('kvm_host') }}"
 export VIRTHOST_KVM_PASSWORD="linux"
 {% else %}# no KVM host defined {% endif %}
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
+export SUMA_HTTP_PROXY="{{ grains.get('http_proxy') }}"
 
 # Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then


### PR DESCRIPTION
PR adds variable `http_proxy` to be used by testsuite. The variable specifies hostname and port for HTTP proxy on SUSE Manager. https://github.com/SUSE/spacewalk/issues/7726