### PR TITLE
[WIP] Fix: use bigger flavor for SLES15SP1

### DIFF
--- a/modules/openstack/suse_manager/variables.tf
+++ b/modules/openstack/suse_manager/variables.tf
@@ -215,7 +215,7 @@ variable "image" {
 
 variable "flavor" {
   description = "OpenStack flavor"
-  default = "m1.medium"
+  default = "m1.large"
 }
 
 variable "floating_ips" {


### PR DESCRIPTION
Without this patch you will not be able to spin up HEAD on SLES15SP1 as
it requires a bigger disk