### PR TITLE
Virthost fixes

### DIFF
--- a/modules/libvirt/virthost/main.tf
+++ b/modules/libvirt/virthost/main.tf
@@ -17,6 +17,7 @@ module "virthost" {
   additional_grains = <<EOF
 
 hvm_disk_image: "${var.hvm_disk_image}"
+hvm_disk_image_hash: "${var.hvm_disk_image_hash}"
 virtual_host: true
 EOF
 

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -69,6 +69,11 @@ variable "hvm_disk_image" {
   default = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse423.x86_64.qcow2"
 }
 
+variable "hvm_disk_image_hash" {
+  description = "Hash of the the disk image, either a URL or the hash itself. See salt's file.managed source_hash documentations"
+  default = "https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/images:/libvirt/images/opensuse423.x86_64.qcow2.sha256"
+}
+
 // Provider-specific variables
 
 variable "image" {

--- a/modules/libvirt/virthost/variables.tf
+++ b/modules/libvirt/virthost/variables.tf
@@ -77,7 +77,7 @@ variable "hvm_disk_image_hash" {
 // Provider-specific variables
 
 variable "image" {
-  description = "One of: sles12sp3, sles15, opensuse423 or opensuse150"
+  description = "One of: sles15, sles15sp1 or opensuse150"
   type = "string"
 }
 

--- a/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Pool.repo
+++ b/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Pool.repo
@@ -1,0 +1,5 @@
+[SLE-Module-Server-Applications-SLE-15-x86_64-Pool]
+name=SLE-Module-Server-Applications-SLE-15-x86_64-Pool
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/

--- a/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Update.repo
+++ b/salt/repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Update.repo
@@ -1,0 +1,5 @@
+[SLE-Module-Server-Applications-SLE-15-x86_64-Update]
+name=SLE-Module-Server-Applications-SLE-15-x86_64-Update
+type=rpm-md
+enabled=1
+baseurl=http://{{ grains.get("mirror") | default("download.suse.de/ibs", true) }}/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update/

--- a/salt/repos/virthost.sls
+++ b/salt/repos/virthost.sls
@@ -1,6 +1,19 @@
 {% if grains.get('virtual_host') | default(false, true) %}
 
-{% if grains['osfullname'] != 'Leap' and '15' in grains['osrelease']  %}
+{% if grains['osfullname'] == 'SLES' %}
+{% if grains['osrelease'] == '15' %}
+module_server_applications_pool_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Pool.repo
+    - template: jinja
+
+module_server_applications_update_repo:
+  file.managed:
+    - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
+    - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-x86_64-Update.repo
+    - template: jinja
+{% elif grains['osrelease'] == '15.1' %}
 module_server_applications_pool_repo:
   file.managed:
     - name: /etc/zypp/repos.d/Module_Server_Applications_Pool.repo
@@ -12,6 +25,7 @@ module_server_applications_update_repo:
     - name: /etc/zypp/repos.d/Module_Server_Applications_Update.repo
     - source: salt://repos/repos.d/SLE-Module-Server-Applications-SLE-15-SP1-x86_64-Update.repo
     - template: jinja
+{% endif %}
 {% endif %}
 
 {% endif %}

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -15,6 +15,7 @@ virthost_packages:
         - libvirt-client
         - qemu-tools
         - guestfs-tools
+        - tar # HACK: workaround missing supermin tar dependency. See boo#1134334
     - require:
       - sls: repos
 

--- a/salt/virthost/init.sls
+++ b/salt/virthost/init.sls
@@ -142,6 +142,10 @@ disk-image-template.qcow2:
   file.managed:
     - name: /var/testsuite-data/disk-image-template.qcow2
     - source: {{ grains['hvm_disk_image'] }}
+    {% if grains['hvm_disk_image_hash'] %}
+    - source_hash: {{ grains['hvm_disk_image_hash'] }}
+    {% else %}
     - skip_verify: True
+    {% endif %}
     - mode: 655
     - makedirs: True


### PR DESCRIPTION
A bunch of fixes for the new virt host module.
Ruled out the 12 family: too much of a pain with libguestfs.