### PR TITLE
Let a minion contain an avahi reflector if desired

### DIFF
--- a/main.tf.libvirt-testsuite.example
+++ b/main.tf.libvirt-testsuite.example
@@ -13,6 +13,7 @@ module "base" {
   // pool = "default"
   // network_name = "default" // change to "" if you change bridge below
   // bridge = ""
+  // use_avahi = true
   // additional_network = ""
   // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
@@ -78,6 +79,7 @@ module "min-sles12sp3" {
   server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
+  // avahi_reflector = true  // uncomment if you kept Avahi enabled, and use Docker containers on the minion
 }
 
 # optional
@@ -110,7 +112,7 @@ module "min-ubuntu" {
   name = "min-ubuntu"
   image = "ubuntu1804"
   memory = 1024
-  server_configuration =  { hostname =  "srv.tf.local" }
+  server_configuration =  { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }

--- a/main.tf.libvirt.example
+++ b/main.tf.libvirt.example
@@ -10,10 +10,11 @@ module "base" {
 
   // optional parameters with defaults below
   // pool = "default"
-  // network_name = "default"
+  // network_name = "default" // change to "" if you change bridge below
   // bridge = ""
+  // use_avahi = true
   // additional_network = ""
-  // name_prefix = ""
+  // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
 }
 

--- a/main.tf.openstack-testsuite.example
+++ b/main.tf.openstack-testsuite.example
@@ -19,9 +19,9 @@ module "base" {
   testsuite = true
 
   // optional parameters with defaults below
-  // name_prefix = ""
+  // use_avahi = true
+  // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
-  // additional_network = ""
 
   // comment out the following two lines if you are not targeting the SUSE internal "ECP" Cloud
   mirror = "mirror.tf.local"
@@ -71,7 +71,7 @@ module "cli-sles12sp3" {
   product_version = "3.1-nightly"
   name = "cli-sles12sp3"
   image = "sles12sp3"
-  server_configuration = { hostname = "srv.tf.local" }
+  server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_register = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }
@@ -82,9 +82,10 @@ module "min-sles12sp3" {
   product_version = "3.1-nightly"
   name = "min-sles12sp3"
   image = "sles12sp3"
-  server_configuration = { hostname = "srv.tf.local" }
+  server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
+  // avahi_reflector = true // uncomment if you kept Avahi enabled, and use Docker containers on the minion
 }
 
 # optional
@@ -104,7 +105,7 @@ module "min-centos7" {
   product_version = "3.1-nightly"
   name = "min-centos7"
   image = "centos7"
-  server_configuration = { hostname = "srv.tf.local" }
+  server_configuration = { hostname = "srv.tf.local" } // make sure to prepend the name_prefix, if used
   auto_connect_to_master = false
   ssh_key_path = "./salt/controller/id_rsa.pub"
 }

--- a/main.tf.openstack.example
+++ b/main.tf.openstack.example
@@ -18,10 +18,11 @@ module "base" {
   cc_password = ...
 
   // optional parameters with defaults below
-  // name_prefix = ""
+  // use_avahi = true
+  // name_prefix = "" // if you use name_prefix, make sure to update the server_configuration for clients/minions below
   // timezone = "Europe/Berlin"
 
-  // comment-out the following two lines if you are not targeting the SUSE internal "ECP" Cloud
+  // comment out the following two lines if you are not targeting the SUSE internal "ECP" Cloud
   mirror = "mirror.tf.local"
   use_shared_resources = true
 }

--- a/modules/libvirt/README.md
+++ b/modules/libvirt/README.md
@@ -26,24 +26,31 @@
 
 ## Accessing VMs
 
-All machines come with avahi's mDNS configured by default on the `.tf.local` domain, and user `root` with password `linux` accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`).
+All machines come with user `root` with password `linux`. They are also accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`) if you have one.
 
-Thus if your host is on the same network segment of the virtual machines you can simply use:
+By default, the machines use Avahi (mDNS), and are configured on the `.tf.local` domain. Thus if your host is on the same network segment of the virtual machines you can simply use:
+
 ```
-ssh root@moio-suma3pg.tf.local
+ssh root@suma32pg.tf.local
 ```
 
-If you want to use a different SSH key, or mDNS does not work out of the box, or if you don't want to use mDNS, please check the README_ADVANCED.md and TROUBLESHOOTING.md files.
+If you use Avahi and are on another network segment, you can only connect using an IP address, because mDNS packets do not cross network boundaries unless using reflectors.
+
+If you want to use a different SSH key, please check the README_ADVANCED.md file, in section "Custom SSH keys".
+If you don't want to use mDNS, or want to forward Avahi between networks, please check that same file, in section "Disabling Avahi and Avahi reflectors".
+If mDNS does not work out of the box, please check TROUBLESHOOTING.md file, under question "How can I work around name resolution problems with `tf.local` mDNS/Zeroconf/Bonjour/Avahi names?".
 
 Web access is on standard ports, so `firefox suma3pg.tf.local` will work as expected. SUSE Manager default user is `admin` with password `admin`.
 
-Avahi can be disabled if it is not needed (bridged networking mode, all VMs with static MAC addresses and names known in advance). In that case use the following variables in the `base` module:
-```hcl
-use_avahi = false
-domain = "mgr.suse.de"
-```
+Finally, the images come with serial console support, so you can use
 
-## mirror
+```
+virsh console suma32pg
+```
+especially in the case the network is not working and you need to debug it, or if the images have difficulties booting.
+
+
+## Mirror
 
 If you are using `sumaform` outside of the SUSE Nuremberg network you should use a special extra virtual machine named `mirror` that will cache packages downloaded from the SUSE engineering network for faster access and lower bandwidth consumption.
 

--- a/modules/libvirt/minion/main.tf
+++ b/modules/libvirt/minion/main.tf
@@ -21,6 +21,7 @@ server: ${var.server_configuration["hostname"]}
 role: minion
 auto_connect_to_master: ${var.auto_connect_to_master}
 apparmor: ${var.apparmor}
+avahi_reflector: ${var.avahi_reflector}
 
 susemanager:
   activation_key: ${var.activation_key}

--- a/modules/libvirt/minion/variables.tf
+++ b/modules/libvirt/minion/variables.tf
@@ -53,6 +53,11 @@ variable "apparmor" {
   default = false
 }
 
+variable "avahi_reflector" {
+  description = "if using avahi, let the daemon be a reflector"
+  default = false
+}
+
 variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}

--- a/modules/openstack/README.md
+++ b/modules/openstack/README.md
@@ -20,18 +20,25 @@
 
 ## Accessing VMs
 
-All machines come with avahi's mDNS configured by default on the `.tf.local` domain, and user `root` with password `linux` accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`).
+All machines come with user `root` with password `linux`. They are also accessible via your SSH public key (by default `~/.ssh/id_rsa.pub`) if you have one.
 
-Thus if your host is on the same network segment of the virtual machines you can simply use:
+By default, the machines use Avahi (mDNS), and are configured on the `.tf.local` domain. Thus if your host is on the same network segment of the virtual machines you can simply use:
 ```
 ssh root@susemanager-suma31pg.tf.local
 ```
 
-Otherwise, you can look in the OpenStack admin Web UI for the floating IPs.
+If you use Avahi and are on another network segment, you can only connect using an IP address, because mDNS packets do not cross network boundaries unless using reflectors.
 
-If you want to use a different SSH key, or mDNS does not work out of the box, or if you don't want to use mDNS, please check the README_ADVANCED.md and TROUBLESHOOTING.md files.
+Public IP addresses, called floating IPs, are output by `terraform apply` and can also be seen in the OpenStack admin Web UI.
 
-Web access is on standard ports, so `firefox <IP_HOST>` will work as expected. SUSE Manager default user is `admin` with password `admin`.
+If you want to use a different SSH key, please check the README_ADVANCED.md file, in section "Custom SSH keys".
+If you don't want to use mDNS, or want to forward Avahi between networks, please check that same file, in section "Disabling Avahi and Avahi reflectors".
+If mDNS does not work out of the box, please check TROUBLESHOOTING.md file, under question "How can I work around name resolution problems with `tf.local` mDNS/Zeroconf/Bonjour/Avahi names?".
+
+Web access is on standard ports, so `firefox <FLOATING_IP_ADDRESS>` will work as expected. SUSE Manager default user is `admin` with password `admin`.
+
+Finally, you can use the Openstack web console to access your VM.
+
 
 ## Customize virtual hardware
 

--- a/modules/openstack/minion/main.tf
+++ b/modules/openstack/minion/main.tf
@@ -19,6 +19,7 @@ server: ${var.server_configuration["hostname"]}
 role: minion
 auto_connect_to_master: ${var.auto_connect_to_master}
 apparmor: ${var.apparmor}
+avahi_reflector: ${var.avahi_reflector}
 
 susemanager:
   activation_key: ${var.activation_key}

--- a/modules/openstack/minion/variables.tf
+++ b/modules/openstack/minion/variables.tf
@@ -53,6 +53,11 @@ variable "apparmor" {
   default = false
 }
 
+variable "avahi_reflector" {
+  description = "if using avahi, let the daemon be a reflector"
+  default = false
+}
+
 variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
   default = {}

--- a/salt/minion/init.sls
+++ b/salt/minion/init.sls
@@ -2,6 +2,7 @@ include:
   - repos
   - minion.testsuite
   - minion.apparmor
+  - minion.reflector
 
 minion_package:
   pkg.installed:

--- a/salt/minion/reflector.sls
+++ b/salt/minion/reflector.sls
@@ -1,0 +1,17 @@
+{% if grains.get('use_avahi') and grains.get('avahi_reflector') %}
+
+reflector_configuration:
+  file.replace:
+    - name: /etc/avahi/avahi-daemon.conf
+    - pattern: "#enable-reflector=no"
+    - repl: "enable-reflector=yes"
+
+reflector_service:
+  service.running:
+    - name: avahi-daemon
+    - enable: True
+    - running: True
+    - watch:
+      - file: /etc/avahi/avahi-daemon.conf
+
+{% endif %}

--- a/salt/minion/reflector.sls
+++ b/salt/minion/reflector.sls
@@ -1,5 +1,27 @@
 {% if grains.get('use_avahi') and grains.get('avahi_reflector') %}
 
+# We upgrade to latest version because of a bug in Avahi:
+#   https://github.com/lathiat/avahi/issues/117
+# It does not remove the problem, but makes it less likely to happen
+reflector_package:
+  pkg.latest:
+    - pkgs:
+      {% if grains['os'] == 'SUSE' %}
+      - avahi
+      - avahi-lang
+      - libavahi-common3
+      - libavahi-core7
+      {% elif grains['os'] == 'Ubuntu' %}
+      - avahi-daemon
+      - libavahi-common-data
+      - libavahi-common3
+      - libavahi-core7
+      {% elif grains['os_family'] == 'RedHat' %}
+      - avahi
+      - avahi-libs
+      {% endif %}
+    - refresh: true
+
 reflector_configuration:
   file.replace:
     - name: /etc/avahi/avahi-daemon.conf


### PR DESCRIPTION
An Avahi reflector can forward mDNS packets between two network cards belonging to different networks.

This PR introduces a new setting, `avahi_reflector`,  that lets a minion act as a reflector. It can then for example forward packets between the minion's `eth0` card and the network interface of a Docker container on that minion. This is needed to run the container tests of the test suite when the VMs have no DNS entries.

This PR sometimes triggers a known Avahi bug, https://github.com/lathiat/avahi/issues/117.