### PR TITLE
If "use_avahi = false", then disable Avahi

### DIFF
--- a/salt/default/minimal.sls
+++ b/salt/default/minimal.sls
@@ -3,9 +3,7 @@ include:
   {% if grains['hostname'] and grains['domain'] %}
   - default.hostname
   {% endif %}
-  {% if grains['use_avahi'] %}
   - default.avahi
-  {% endif %}
 
 minimal_package_update:
   pkg.latest:


### PR DESCRIPTION
If we set up
```
  use_avahi = false
```

then it's a good idea to disable Avahi:
1. it can only improve the performance :smile_cat: ;
2. it avoids triggering some product bugs, like the dependence of base Salt grains towards name resolution (https://bugzilla.suse.com/show_bug.cgi?id=1134860);
3. it seems coherent with the expected semantics.

Note: it is **not** a fix for the presence ping problem, only a workaround.