### PR TITLE
Reduce "tcp_keepalive_idle" value on proxy to workaround connections hangs

### DIFF
--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -202,7 +202,7 @@ ca-configuration-checksum:
 
 {% endif %}
 
-reduce_tcp_keepalive_idle_on_proxy:
+TEMPORARY_WORKAROUND_reduce_tcp_keepalive_idle_on_proxy:
   file.managed:
     - name: /etc/salt/minion.d/keepalive.conf
     - makedirs: True

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -201,3 +201,15 @@ ca-configuration-checksum:
       - file: ca-configuration
 
 {% endif %}
+
+reduce_tcp_keepalive_idle_on_proxy:
+  file.managed:
+    - name: /etc/salt/minion.d/keepalive.conf
+    - makedirs: True
+    - contents: |
+        tcp_keepalive: True
+        tcp_keepalive_idle: 20
+        tcp_keepalive_cnt: -1
+        tcp_keepalive_intvl: -1
+    - require:
+      - pkg: proxy-packages


### PR DESCRIPTION
This is a workaround that reduce the value for `tcp_keepalive_idle` to 20 seconds instead of 300 (default).

There is currently an issue when the SUSE Manager proxy is configured and registered on SUSE Manager. The `state.apply` which is executed to configure the proxy is doing changes on the network and it's also enabling the firewall on the proxy. It seems this is producing the already established connection from the `salt-minion` process on the proxy and the `salt-master` hangs.

Before this PR, the TCP connection (4505) will get restrablised after 300 seconds, which is making some testsuite scenario to fail.

This PR workaround this issue by reducing the `tcp_keepalive_idle` to 20 seconds. Already tested.

**NOTE:** This issue only happening in our testsuite infrastructure and not locally.