### PR TITLE
Empty variable for http proxy should not be defined

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -41,7 +41,7 @@ pxeboot_mac: ${var.pxeboot_configuration["macaddr"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
-http_proxy: ${var.http_proxy}
+server_http_proxy: ${var.server_http_proxy}
 
 EOF
 

--- a/modules/libvirt/controller/variables.tf
+++ b/modules/libvirt/controller/variables.tf
@@ -117,7 +117,7 @@ variable "git_profiles_repo" {
   default = "default"
 }
 
-variable "http_proxy" {
+variable "server_http_proxy" {
   description = "Define hostname and port used by SUSE Manager http proxy"
   default = ""
 }

--- a/modules/openstack/controller/main.tf
+++ b/modules/openstack/controller/main.tf
@@ -37,7 +37,7 @@ ssh_minion: ${var.minionssh_configuration["hostname"]}
 role: controller
 branch: ${var.branch == "default" ? lookup(var.testsuite-branch, var.server_configuration["product_version"]) : var.branch}
 git_profiles_repo: ${var.git_profiles_repo == "default" ? "https://github.com/uyuni-project/uyuni.git#master:testsuite/features/profiles" : var.git_profiles_repo}
-http_proxy: ${var.http_proxy}
+server_http_proxy: ${var.server_http_proxy}
 
 EOF
 

--- a/modules/openstack/controller/variables.tf
+++ b/modules/openstack/controller/variables.tf
@@ -24,7 +24,7 @@ variable "git_repo" {
   default = "default"
 }
 
-variable "http_proxy" {
+variable "server_http_proxy" {
   description = "Define hostname and port used by SUSE Manager http proxy"
   default = ""
 }

--- a/salt/controller/bashrc
+++ b/salt/controller/bashrc
@@ -14,7 +14,7 @@ export VIRTHOST_KVM_URL="{{ grains.get('kvm_host') }}"
 export VIRTHOST_KVM_PASSWORD="linux"
 {% else %}# no KVM host defined {% endif %}
 export GITPROFILES="{{ grains.get('git_profiles_repo') }}"
-export SUMA_HTTP_PROXY="{{ grains.get('http_proxy') }}"
+{% if grains.get('server_http_proxy') | default(false, true) %}export SERVER_HTTP_PROXY="{{ grains.get('server_http_proxy') }}" {% else %}# no server HTTP proxy defined {% endif %}
 
 # Generate certificates for Google Chrome
 if [ ! -f /etc/pki/trust/anchors/$SERVER.cert ]; then


### PR DESCRIPTION
Environment variable `SUMA_HTTP_PROXY` shouldn't be declared in `.bashrc` in case `http_proxy` is undefined or has an empty string as a value in `main.tf`.