### PR TITLE
Enable "conntrack" kernal modules on the Proxy to avoid hanging connections

### DIFF
--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -201,3 +201,20 @@ ca-configuration-checksum:
       - file: ca-configuration
 
 {% endif %}
+
+
+# HACK: This avoids already established connections to hang
+# when SuSEfirewall2 is started by the retail formula
+preload_conntrack_modules_and_enable_them_at_boottime:
+  file.managed:
+    - name: /etc/modules-load.d/nf_conntrack.conf
+    - content: |
+        nf_conntrack_ipv4
+        nf_conntrack_ipv6
+        nf_conntrack
+    - require:
+      - pkg: proxy-packages
+  cmd.run:
+    - name: modprobe nf_conntrack_ipv4 && modprobe nf_conntrack_ipv6
+    - require:
+      - pkg: proxy-packages

--- a/salt/suse_manager_proxy/init.sls
+++ b/salt/suse_manager_proxy/init.sls
@@ -201,15 +201,3 @@ ca-configuration-checksum:
       - file: ca-configuration
 
 {% endif %}
-
-TEMPORARY_WORKAROUND_reduce_tcp_keepalive_idle_on_proxy:
-  file.managed:
-    - name: /etc/salt/minion.d/keepalive.conf
-    - makedirs: True
-    - contents: |
-        tcp_keepalive: True
-        tcp_keepalive_idle: 20
-        tcp_keepalive_cnt: -1
-        tcp_keepalive_intvl: -1
-    - require:
-      - pkg: proxy-packages


### PR DESCRIPTION
This PR removes the `tcp_keepalive_idle` workaround on the Proxy, and preload the `conntrack` kernel modules to actually avoid the connections to hangs when `SuSEfirewall2` is started.