### PR TITLE
Fix default system locale to "LANG=en_US.UTF-8" for all hosts

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -1,4 +1,5 @@
 include:
+  - default.locale
   - default.minimal
   - default.pkgs
   {% if grains.get('reset_ids') | default(false, true) %}

--- a/salt/default/locale.sls
+++ b/salt/default/locale.sls
@@ -1,0 +1,3 @@
+fix_en_US_UTF8_as_system_local:
+  cmd.run:
+    - name: localectl set-locale LANG=en_US.UTF-8


### PR DESCRIPTION
This PR sets the default locale to `LANG=en_US.UTF-8` in all sumaform hosts to workaround the inconsistent state where some hosts may not have any default locale assigned.

This situations leads into `UnicodeDecodeErrors` when running `salt-ssh` from a system which does not have any default locale set.