### PR TITLE
Move controller from opensuse42.3 to opensuse15.0

### DIFF
--- a/modules/libvirt/controller/main.tf
+++ b/modules/libvirt/controller/main.tf
@@ -46,7 +46,7 @@ server_http_proxy: ${var.server_http_proxy}
 EOF
 
   // Provider-specific variables
-  image = "opensuse423"
+  image = "opensuse150"
   vcpu = "${var.vcpu}"
   memory = "${var.memory}"
   running = "${var.running}"

--- a/salt/controller/init.sls
+++ b/salt/controller/init.sls
@@ -51,7 +51,7 @@ cucumber_requisites:
       - libxslt-devel
       - mozilla-nss-tools
       # packaged ruby gems
-      - ruby2.1-rubygem-bundler
+      - ruby2.5-rubygem-bundler
       - twopence
       - rubygem-twopence
     - require:
@@ -74,7 +74,8 @@ create_syslink_for_chromedriver:
 
 install_gems_via_bundle:
   cmd.run:
-    - name: bundle.ruby2.1 install --gemfile /root/spacewalk/testsuite/Gemfile
+    - name: bundle.ruby2.5 install --gemfile Gemfile
+    - cwd: /root/spacewalk/testsuite
     - require:
       - pkg: cucumber_requisites
       - cmd: spacewalk_git_repository


### PR DESCRIPTION
This is an **emergency fix**. This PR moves controller from opensuse42.3 to opensuse15.0 to address these two problems:

1 - head test suite is not deploying anymore, displaying the error
```
Gem::InstallError: public_suffix requires Ruby version >= 2.3.
```

2 - opensuse42.3 will be deprecated soon

By changing opensuse42.3 to to opensuse15.0, we also change ruby 2.1 to ruby 2.5, which fixes the gem installation error.

Fixes SUSE/spacewalk#7928 .