### PR TITLE
Do not use "localectl" on SLE11 systems

### DIFF
--- a/salt/default/locale.sls
+++ b/salt/default/locale.sls
@@ -1,3 +1,27 @@
+{% if grains.get('osmajorrelease', None)|int() == 11 %}
+
+set_locale_rc_lang_on_sle11:
+  file.replace:
+    - name: /etc/sysconfig/language
+    - pattern: ^RC_LANG=".*"
+    - repl: RC_LANG="en_US.UTF-8"
+
+set_locale_root_uses_lang_on_sle11:
+  file.replace:
+    - name: /etc/sysconfig/language
+    - pattern: ^ROOT_USES_LANG=".*"
+    - repl: ROOT_USES_LANG="ctype"
+
+set_locale_installed_languages_on_sle11:
+  file.replace:
+    - name: /etc/sysconfig/language
+    - pattern: ^INSTALLED_LANGUAGES=".*"
+    - repl: INSTALLED_LANGUAGES=""
+
+{% else %}
+
 fix_en_US_UTF8_as_system_local:
   cmd.run:
     - name: localectl set-locale LANG=en_US.UTF-8
+
+{% endif %}

--- a/salt/default/locale.sls
+++ b/salt/default/locale.sls
@@ -1,18 +1,18 @@
-set_locale_rc_lang_on_sle11:
+manually_set_locale_rc_lang:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^RC_LANG=".*"
     - repl: RC_LANG="en_US.UTF-8"
     - onlyif: test ! -f /usr/bin/localectl
 
-set_locale_root_uses_lang_on_sle11:
+manually_set_locale_root_uses_lang:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^ROOT_USES_LANG=".*"
     - repl: ROOT_USES_LANG="ctype"
     - onlyif: test ! -f /usr/bin/localectl
 
-set_locale_installed_languages_on_sle11:
+manually_set_locale_installed_languages:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^INSTALLED_LANGUAGES=".*"

--- a/salt/default/locale.sls
+++ b/salt/default/locale.sls
@@ -1,27 +1,25 @@
-{% if grains.get('osmajorrelease', None)|int() == 11 %}
-
 set_locale_rc_lang_on_sle11:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^RC_LANG=".*"
     - repl: RC_LANG="en_US.UTF-8"
+    - onlyif: test ! -f /usr/bin/localectl
 
 set_locale_root_uses_lang_on_sle11:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^ROOT_USES_LANG=".*"
     - repl: ROOT_USES_LANG="ctype"
+    - onlyif: test ! -f /usr/bin/localectl
 
 set_locale_installed_languages_on_sle11:
   file.replace:
     - name: /etc/sysconfig/language
     - pattern: ^INSTALLED_LANGUAGES=".*"
     - repl: INSTALLED_LANGUAGES=""
+    - onlyif: test ! -f /usr/bin/localectl
 
-{% else %}
-
-fix_en_US_UTF8_as_system_local:
+fix_en_US_UTF8_as_system_locale_with_localectl:
   cmd.run:
     - name: localectl set-locale LANG=en_US.UTF-8
-
-{% endif %}
+    - onlyif: test -f /usr/bin/localectl


### PR DESCRIPTION
This PR configures `en_US.UTF-8` as default locale on SLE11 where `localectl` command is not available.